### PR TITLE
Testing and logging improvements

### DIFF
--- a/bin/mint-server-https/main.go
+++ b/bin/mint-server-https/main.go
@@ -13,7 +13,7 @@ func main() {
 	listener, err := mint.Listen("tcp", service, &mint.Config{})
 
 	if err != nil {
-		log.Println("Error: %v", err)
+		log.Printf("Error: %v", err)
 	}
 
 	http.HandleFunc("/", handleClient)

--- a/common_test.go
+++ b/common_test.go
@@ -53,6 +53,6 @@ func (e errorReadWriter) Read(p []byte) (n int, err error) {
 	return 0, fmt.Errorf("Unknown read error")
 }
 
-func (ew errorReadWriter) Write(p []byte) (n int, err error) {
+func (e errorReadWriter) Write(p []byte) (n int, err error) {
 	return 0, fmt.Errorf("Unknown write error")
 }

--- a/crypto.go
+++ b/crypto.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
-	"log"
 	"math/big"
 
 	// Blank includes to ensure hash support
@@ -212,9 +211,9 @@ func sign(hash crypto.Hash, privateKey crypto.Signer, data []byte, context strin
 	var opts crypto.SignerOpts
 	var sigAlg signatureAlgorithm
 
-	log.Printf("digest to be verified: %x", data)
+	logf(logTypeCrypto, "digest to be verified: %x", data)
 	digest := encodeSignatureInput(hash, data, context)
-	log.Printf("digest with context: %x", digest)
+	logf(logTypeCrypto, "digest with context: %x", digest)
 
 	switch privateKey.(type) {
 	case *rsa.PrivateKey:
@@ -230,6 +229,7 @@ func sign(hash crypto.Hash, privateKey crypto.Signer, data []byte, context strin
 	}
 
 	sig, err := privateKey.Sign(prng, digest, opts)
+	logf(logTypeCrypto, "signature: %x", sig)
 	return sigAlg, sig, err
 }
 
@@ -331,11 +331,11 @@ func hkdfExpandLabel(hash crypto.Hash, secret []byte, label string, hashValue []
 	info := hkdfEncodeLabel(label, hashValue, outLen)
 	derived := hkdfExpand(hash, secret, info, outLen)
 
-	log.Printf("HKDF Expand: label=[TLS 1.3, ] + '%s',requested length=%d\n", label, outLen)
-	log.Printf("PRK [%d]: %x\n", len(secret), secret)
-	log.Printf("Hash [%d]: %x\n", len(hashValue), hashValue)
-	log.Printf("Info [%d]: %x\n", len(info), info)
-	log.Printf("Derived key [%d]: %x\n", len(derived), derived)
+	logf(logTypeCrypto, "HKDF Expand: label=[TLS 1.3, ] + '%s',requested length=%d\n", label, outLen)
+	logf(logTypeCrypto, "PRK [%d]: %x\n", len(secret), secret)
+	logf(logTypeCrypto, "Hash [%d]: %x\n", len(hashValue), hashValue)
+	logf(logTypeCrypto, "Info [%d]: %x\n", len(info), info)
+	logf(logTypeCrypto, "Derived key [%d]: %x\n", len(derived), derived)
 
 	return derived
 }
@@ -496,12 +496,12 @@ func (c *cryptoContext) Update(messages []*handshakeMessage) error {
 	// Compute client_finished_key and client Finished
 	h.Write(finishedMessage.Marshal())
 	handshakeHash = h.Sum(nil)
-	log.Printf("handshake hash for client Finished: [%d] %x", len(handshakeHash), handshakeHash)
+	logf(logTypeCrypto, "handshake hash for client Finished: [%d] %x", len(handshakeHash), handshakeHash)
 
 	clientFinishedMAC := hmac.New(c.params.hash.New, c.clientFinishedKey)
 	clientFinishedMAC.Write(handshakeHash)
 	c.clientFinishedData = clientFinishedMAC.Sum(nil)
-	log.Printf("client Finished data: [%d] %x", len(handshakeHash), handshakeHash)
+	logf(logTypeCrypto, "client Finished data: [%d] %x", len(handshakeHash), handshakeHash)
 
 	c.clientFinished = &finishedBody{
 		verifyDataLen: L,

--- a/crypto.go
+++ b/crypto.go
@@ -421,6 +421,9 @@ func (c *cryptoContext) Init(ch, sh *handshakeMessage, SS, ES []byte, suite ciph
 	c.transcript = []*handshakeMessage{}
 
 	// Add ClientHello, ServerHello to transcript
+	if ch == nil || sh == nil {
+		return fmt.Errorf("tls.cryptoinit: Nil message provided")
+	}
 	c.transcript = append(c.transcript, []*handshakeMessage{ch, sh}...)
 
 	// Compute xSS, xES = HKDF-Extract(0, ES)
@@ -448,6 +451,11 @@ func (c *cryptoContext) Update(messages []*handshakeMessage) error {
 	}
 
 	// Add messages to transcript
+	for _, msg := range messages {
+		if msg == nil {
+			return fmt.Errorf("tls.updatecontext: Nil message")
+		}
+	}
 	c.transcript = append(c.transcript, messages...)
 	handshakeSoFar := c.marshalTranscript()
 

--- a/crypto.go
+++ b/crypto.go
@@ -485,14 +485,12 @@ func (c *cryptoContext) Update(messages []*handshakeMessage) error {
 	serverFinishedMAC.Write(handshakeHash)
 	c.serverFinishedData = serverFinishedMAC.Sum(nil)
 	c.serverFinished = &finishedBody{
-		verifyDataLen: L,
+		verifyDataLen: len(c.serverFinishedData),
 		verifyData:    c.serverFinishedData,
 	}
 
-	finishedMessage, err := handshakeMessageFromBody(c.serverFinished)
-	if err != nil {
-		return err
-	}
+	// This call can only fail if there's a length mismatch, which can't happen here
+	finishedMessage, _ := handshakeMessageFromBody(c.serverFinished)
 	c.transcript = append(c.transcript, finishedMessage)
 
 	// Compute client_finished_key and client Finished

--- a/crypto.go
+++ b/crypto.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"math/big"
 
+	// Blank includes to ensure hash support
 	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
@@ -321,7 +322,7 @@ func hkdfExpand(hash crypto.Hash, prk, info []byte, outLen int) []byte {
 
 		T = h.Sum(nil)
 		out = append(out, T...)
-		i += 1
+		i++
 	}
 	return out[:outLen]
 }

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -188,6 +188,9 @@ func TestSignVerify(t *testing.T) {
 	assertError(t, err, "Verified RSA with something other than PSS")
 	allowPKCS1 = originalAllowPKCS1
 
+	err = verify(algECDSA, privRSA.Public(), data, context, sigRSA)
+	assertError(t, err, "Verified RSA with a non-RSA algorithm")
+
 	// Test ECDSA verify failure on bad algorithm
 	err = verify(algRSAPSS, privECDSA.Public(), data, context, sigECDSA)
 	assertError(t, err, "Verified ECDSA with a bad algorithm")
@@ -352,11 +355,11 @@ func TestCryptoContext(t *testing.T) {
 
 	// Test Init failure on nil messages
 	ctx = cryptoContext{}
-	err = ctx.Init(nil, shm, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+	err = ctx.Init(nil, shm, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
 	assertError(t, err, "Init'ed context with nil clientHello")
 
 	ctx = cryptoContext{}
-	err = ctx.Init(chm, nil, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+	err = ctx.Init(chm, nil, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
 	assertError(t, err, "Init'ed context with nil clientHello")
 
 	// Test that Update failes on un-Init'ed context

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -33,8 +33,8 @@ var (
 	hkdfExpandLen            = 42
 	hkdfLabel                = "test"
 	hkdfHashHex              = "f9a54250131c827542664bcad131b87c09cdd92f0d5f84db3680ee4c0c0f8ed6" // random
-	hkdfEncodedLabelHex      = "002a" + "0c" + hex.EncodeToString([]byte("TLS 1.3,"+hkdfLabel)) + "20" + hkdfHashHex
-	hkdfExpandLabelOutputHex = "cca90009033b529a7fd768fc49e111aacb04dd4f86f309ed4a7faf4c91ee14bda45f4f1d300c3ec01ab2"
+	hkdfEncodedLabelHex      = "002a" + "0d" + hex.EncodeToString([]byte("TLS 1.3, "+hkdfLabel)) + "20" + hkdfHashHex
+	hkdfExpandLabelOutputHex = "474de877d26b9e14ba50d91657bdf8bdb0fb7152f0ef8d908bb68eb697bb64c6bf2f2d81fa987e86bc32"
 )
 
 func TestNewKeyShare(t *testing.T) {
@@ -142,6 +142,7 @@ func TestSignVerify(t *testing.T) {
 		10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
 		20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 		30, 31}
+	context := "TLS 1.3, test"
 
 	privRSA, err := newSigningKey(signatureAlgorithmRSA)
 	assertNotError(t, err, "failed to generate RSA private key")
@@ -149,54 +150,70 @@ func TestSignVerify(t *testing.T) {
 	assertNotError(t, err, "failed to generate RSA private key")
 
 	// Test successful signing
-	sigAlgRSA, sigRSA, err := sign(crypto.SHA256, privRSA, data)
+	sigAlgRSA, sigRSA, err := sign(crypto.SHA256, privRSA, data, context)
 	assertNotError(t, err, "Failed to generate RSA signature")
-	assertEquals(t, sigAlgRSA, signatureAlgorithmRSAPSS)
+	assertEquals(t, sigAlgRSA, signatureAlgorithmRSA)
 
-	sigAlgECDSA, sigECDSA, err := sign(crypto.SHA256, privECDSA, data)
+	originalAllowPKCS1 := allowPKCS1
+	allowPKCS1 = false
+	sigAlgRSAPSS, sigRSAPSS, err := sign(crypto.SHA256, privRSA, data, context)
+	assertNotError(t, err, "Failed to generate RSA-PSS signature")
+	assertEquals(t, sigAlgRSAPSS, signatureAlgorithmRSAPSS)
+	allowPKCS1 = originalAllowPKCS1
+
+	sigAlgECDSA, sigECDSA, err := sign(crypto.SHA256, privECDSA, data, context)
 	assertNotError(t, err, "Failed to generate ECDSA signature")
 	assertEquals(t, sigAlgECDSA, signatureAlgorithmECDSA)
 
 	// Test successful verification
-	algRSAPSS := signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmRSAPSS}
-	err = verify(algRSAPSS, privRSA.Public(), data, sigRSA)
+	algRSA := signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmRSA}
+	err = verify(algRSA, privRSA.Public(), data, context, sigRSA)
 	assertNotError(t, err, "Failed to verify a valid RSA-PSS signature")
 
+	originalAllowPKCS1 = allowPKCS1
+	allowPKCS1 = false
+	algRSAPSS := signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmRSAPSS}
+	err = verify(algRSAPSS, privRSA.Public(), data, context, sigRSAPSS)
+	assertNotError(t, err, "Failed to verify a valid RSA-PSS signature")
+	allowPKCS1 = originalAllowPKCS1
+
 	algECDSA := signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmECDSA}
-	err = verify(algECDSA, privECDSA.Public(), data, sigECDSA)
+	err = verify(algECDSA, privECDSA.Public(), data, context, sigECDSA)
 	assertNotError(t, err, "Failed to verify a valid ECDSA signature")
 
 	// Test RSA verify failure on bad algorithm
-	algRSA := signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmRSA}
-	err = verify(algRSA, privRSA.Public(), data, sigRSA)
+	originalAllowPKCS1 = allowPKCS1
+	allowPKCS1 = false
+	err = verify(algRSA, privRSA.Public(), data, context, sigRSA)
 	assertError(t, err, "Verified RSA with something other than PSS")
+	allowPKCS1 = originalAllowPKCS1
 
 	// Test ECDSA verify failure on bad algorithm
-	err = verify(algRSAPSS, privECDSA.Public(), data, sigECDSA)
+	err = verify(algRSAPSS, privECDSA.Public(), data, context, sigECDSA)
 	assertError(t, err, "Verified ECDSA with a bad algorithm")
 
 	// Test ECDSA verify failure on ASN.1 unmarshal failure
-	err = verify(algECDSA, privECDSA.Public(), data, sigECDSA[:8])
+	err = verify(algECDSA, privECDSA.Public(), data, context, sigECDSA[:8])
 	assertError(t, err, "Verified ECDSA with a bad ASN.1")
 
 	// Test ECDSA verify failure on trailing data
-	err = verify(algECDSA, privECDSA.Public(), data, append(sigECDSA, data...))
+	err = verify(algECDSA, privECDSA.Public(), data, context, append(sigECDSA, data...))
 	assertError(t, err, "Verified ECDSA with a trailing ASN.1")
 
 	// Test ECDSA verify failure on zero / negative values
 	zeroSigIn := ecdsaSignature{big.NewInt(0), big.NewInt(0)}
 	zeroSig, err := asn1.Marshal(zeroSigIn)
-	err = verify(algECDSA, privECDSA.Public(), data, zeroSig)
+	err = verify(algECDSA, privECDSA.Public(), data, context, zeroSig)
 	assertError(t, err, "Verified ECDSA with zero signature")
 
 	// Test ECDSA verify failure on signature validation failure
 	sigECDSA[7] ^= 0xFF
-	err = verify(algECDSA, privECDSA.Public(), data, sigECDSA)
+	err = verify(algECDSA, privECDSA.Public(), data, context, sigECDSA)
 	assertError(t, err, "Verified ECDSA with corrupted signature")
 	sigECDSA[7] ^= 0xFF
 
 	// Test verify failure on unknown public key type
-	err = verify(algECDSA, struct{}{}, data, sigECDSA)
+	err = verify(algECDSA, struct{}{}, data, context, sigECDSA)
 	assertError(t, err, "Verified with invalid public key type")
 }
 
@@ -253,7 +270,7 @@ var (
 
 	certificateContextIn = &certificateBody{
 		certificateRequestContext: []byte{},
-		certificateList:           make([]*x509.Certificate, 1),
+		certificateList:           []*x509.Certificate{cert1, cert2},
 	}
 
 	certificateVerifyContextIn = &certificateVerifyBody{
@@ -300,6 +317,15 @@ func TestCryptoContext(t *testing.T) {
 		},
 	})
 
+	chm, err := handshakeMessageFromBody(clientHelloContextIn)
+	assertNotError(t, err, "Error in prep [0]")
+	shm, err := handshakeMessageFromBody(serverHelloContextIn)
+	assertNotError(t, err, "Error in prep [1]")
+	cm, err := handshakeMessageFromBody(certificateContextIn)
+	assertNotError(t, err, "Error in prep [2]")
+	cvm, err := handshakeMessageFromBody(certificateVerifyContextIn)
+	assertNotError(t, err, "Error in prep [3]")
+
 	alg := signatureAndHashAlgorithm{hash: hashAlgorithmSHA256, signature: signatureAlgorithmECDSA}
 	priv, err := newSigningKey(signatureAlgorithmECDSA)
 	assertNotError(t, err, "Failed to generate key pair")
@@ -309,7 +335,7 @@ func TestCryptoContext(t *testing.T) {
 
 	// Test successful Init
 	ctx := cryptoContext{}
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
+	err = ctx.Init(chm, shm, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
 	assertNotError(t, err, "Failed to init context")
 	assert(t, ctx.initialized, "Context not marked as initialized after Init")
 	assert(t, len(ctx.transcript) == 2, "Transcript not populated after Init")
@@ -321,35 +347,28 @@ func TestCryptoContext(t *testing.T) {
 
 	// Test Init failure on usupported ciphersuite
 	ctx = cryptoContext{}
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+	err = ctx.Init(chm, shm, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
 	assertError(t, err, "Init'ed context with an unsupported ciphersuite")
 
-	// Test Init failure on CH addToTranscript failure (i.e., marshal failure)
+	// Test Init failure on nil messages
 	ctx = cryptoContext{}
-	originalSuites := clientHelloContextIn.cipherSuites
-	clientHelloContextIn.cipherSuites = []cipherSuite{}
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
-	assertError(t, err, "Init'ed context despite ClientHello marshal failure")
-	clientHelloContextIn.cipherSuites = originalSuites
+	err = ctx.Init(nil, shm, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+	assertError(t, err, "Init'ed context with nil clientHello")
 
-	// Test Init failure on SH addToTranscript failure (i.e., marshal failure)
 	ctx = cryptoContext{}
-	originalExtensions := serverHelloContextIn.extensions
-	serverHelloContextIn.extensions = extListTooLongIn
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
-	assertError(t, err, "Init'ed context despite ServerHello marshal failure")
-	serverHelloContextIn.extensions = originalExtensions
+	err = ctx.Init(chm, nil, SSContextIn, ESContextIn, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256)
+	assertError(t, err, "Init'ed context with nil clientHello")
 
 	// Test that Update failes on un-Init'ed context
 	ctx = cryptoContext{}
-	err = ctx.Update([]handshakeMessageBody{certificateContextIn, certificateVerifyContextIn})
+	err = ctx.Update([]*handshakeMessage{cm, cvm})
 	assertError(t, err, "Allowed Update on un-Init'ed context")
 
 	// Test succesful Update
 	ctx = cryptoContext{}
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
+	err = ctx.Init(chm, shm, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
 	assertNotError(t, err, "Failed to init context before update")
-	err = ctx.Update([]handshakeMessageBody{certificateContextIn, certificateVerifyContextIn})
+	err = ctx.Update([]*handshakeMessage{cm, cvm})
 	assertNotError(t, err, "Failed to update context")
 	assert(t, len(ctx.mES) > 0, "mES not populated after Update")
 	assert(t, len(ctx.mSS) > 0, "mSS not populated after Update")
@@ -363,17 +382,12 @@ func TestCryptoContext(t *testing.T) {
 	assert(t, len(ctx.trafficSecret) > 0, "Traffic secret not populated after Update")
 	assert(t, !keySetEmpty(ctx.applicationKeys), "Application keys not populated after Update")
 
-	// Test Update failure on addToTranscript failure (i.e., marshal failure)
+	// Test Update failure on nil message
 	ctx = cryptoContext{}
-	err = ctx.Init(clientHelloContextIn, serverHelloContextIn, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
+	err = ctx.Init(chm, shm, SSContextIn, ESContextIn, serverHelloContextIn.cipherSuite)
 	assertNotError(t, err, "Failed to init context before update failure test")
-
-	originalContext := certificateContextIn.certificateRequestContext
-	certificateContextIn.certificateRequestContext = bytes.Repeat([]byte{0}, maxCertRequestContextLen+1)
-
-	err = ctx.Update([]handshakeMessageBody{certificateContextIn, certificateVerifyContextIn})
-	assertError(t, err, "Updated context despite marshal failure")
-	certificateContextIn.certificateRequestContext = originalContext
+	err = ctx.Update([]*handshakeMessage{cm, nil})
+	assertError(t, err, "Updated context with nil message")
 
 	// Test key update
 	oldKeys := ctx.applicationKeys

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -109,6 +109,10 @@ var (
 	serverNameRaw = "example.com"
 	serverNameIn  = serverNameExtension(serverNameRaw)
 	serverNameHex = "000e00000b" + hex.EncodeToString([]byte(serverNameRaw))
+
+	// DraftVersion test cases
+	draftVersionIn  = draftVersionExtension{0x2030}
+	draftVersionHex = "2030"
 )
 
 func TestExtensionMarshalUnmarshal(t *testing.T) {
@@ -399,4 +403,28 @@ func TestSignatureAlgorithmsMarshalUnmarshal(t *testing.T) {
 	read, err = sg.Unmarshal(signatureAlgorithms)
 	assertError(t, err, "Unmarshaled a SignatureAlgorithms with an odd-length list")
 	signatureAlgorithms[1]++
+}
+
+func TestDraftVersionMarshalUnmarshal(t *testing.T) {
+	draftVersion, _ := hex.DecodeString(draftVersionHex)
+
+	// Test extension type
+	assertEquals(t, draftVersionExtension{}.Type(), extensionTypeDraftVersion)
+
+	// Test successful marshal
+	out, err := draftVersionIn.Marshal()
+	assertNotError(t, err, "Failed to marshal valid DraftVersion")
+	assertByteEquals(t, out, draftVersion)
+
+	// Test successful unmarshal
+	dv := draftVersionExtension{}
+	read, err := dv.Unmarshal(draftVersion)
+	assertNotError(t, err, "Failed to unmarshal valid DraftVersion")
+	assertDeepEquals(t, dv, draftVersionIn)
+	assertEquals(t, read, len(draftVersion))
+
+	// Test unmarshal failure on wrong data length
+	dv = draftVersionExtension{}
+	read, err = dv.Unmarshal(draftVersion[:1])
+	assertError(t, err, "Unmarshaled a DraftVersion with the wrong length")
 }

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -254,16 +254,16 @@ func TestServerNameMarshalUnmarshal(t *testing.T) {
 	assertError(t, err, "Unmarshaled a ServerName without a full name")
 
 	// Test unmarshal failure on length mismatch
-	serverName[4] += 1
+	serverName[4]++
 	read, err = sni.Unmarshal(serverName)
 	assertError(t, err, "Unmarshaled a ServerName with inconsistent lengths")
-	serverName[4] -= 1
+	serverName[4]--
 
 	// Test unmarshal failure on odd list length
-	serverName[2] += 1
+	serverName[2]++
 	read, err = sni.Unmarshal(serverName)
 	assertError(t, err, "Unmarshaled a ServerName that was not a host_name")
-	serverName[2] -= 1
+	serverName[2]--
 }
 
 func TestKeyShareMarshalUnmarshal(t *testing.T) {
@@ -358,11 +358,11 @@ func TestSupportedGroupsMarshalUnmarshal(t *testing.T) {
 	assertError(t, err, "Unmarshaled a SupportedGroups without a key share length")
 
 	// Test unmarshal failure on odd list length
-	supportedGroups[1] -= 1
+	supportedGroups[1]--
 	sg = supportedGroupsExtension{}
 	read, err = sg.Unmarshal(supportedGroups)
 	assertError(t, err, "Unmarshaled a SupportedGroups with an odd-length list")
-	supportedGroups[1] += 1
+	supportedGroups[1]++
 }
 
 func TestSignatureAlgorithmsMarshalUnmarshal(t *testing.T) {
@@ -394,9 +394,9 @@ func TestSignatureAlgorithmsMarshalUnmarshal(t *testing.T) {
 	assertError(t, err, "Unmarshaled a SignatureAlgorithms without a key share length")
 
 	// Test unmarshal failure on odd list length
-	signatureAlgorithms[1] -= 1
+	signatureAlgorithms[1]--
 	sg = signatureAlgorithmsExtension{}
 	read, err = sg.Unmarshal(signatureAlgorithms)
 	assertError(t, err, "Unmarshaled a SignatureAlgorithms with an odd-length list")
-	signatureAlgorithms[1] += 1
+	signatureAlgorithms[1]++
 }

--- a/handshake-layer.go
+++ b/handshake-layer.go
@@ -198,9 +198,9 @@ func (h *handshakeLayer) WriteMessageBody(body handshakeMessageBody) (*handshake
 	if err != nil {
 		return nil, err
 	}
-	if len(hms) < 1 {
-		return nil, fmt.Errorf("tls.writemessagebody: No handshake message returned")
-	}
+
+	// When it succeeds, WriteMessageBodies always returns as many messages as
+	// bodies were provided in the input array
 	return hms[0], nil
 }
 

--- a/handshake-layer.go
+++ b/handshake-layer.go
@@ -2,7 +2,6 @@ package mint
 
 import (
 	"fmt"
-	"log"
 )
 
 const (
@@ -35,7 +34,7 @@ func (hm handshakeMessage) Marshal() []byte {
 }
 
 func (hm handshakeMessage) toBody() (handshakeMessageBody, error) {
-	log.Printf("handshakeMessage.toBody [%d] [%x]", hm.msgType, hm.body)
+	logf(logTypeHandshake, "handshakeMessage.toBody [%d] [%x]", hm.msgType, hm.body)
 
 	var body handshakeMessageBody
 	switch hm.msgType {
@@ -152,7 +151,7 @@ func (h *handshakeLayer) WriteMessage(hm *handshakeMessage) error {
 
 func (h *handshakeLayer) WriteMessages(hms []*handshakeMessage) error {
 	for _, hm := range hms {
-		log.Printf("hanshakeLayer.WriteMessage [%d] %x", hm.msgType, hm.body)
+		logf(logTypeHandshake, "WriteMessage [%d] %x", hm.msgType, hm.body)
 	}
 
 	// Write out headers and bodies

--- a/handshake-messages.go
+++ b/handshake-messages.go
@@ -417,12 +417,16 @@ func (cv *certificateVerifyBody) Unmarshal(data []byte) (int, error) {
 func (cv *certificateVerifyBody) computeContext(transcript []*handshakeMessage) (hash crypto.Hash, hashed []byte, err error) {
 	handshakeContext := []byte{}
 	for _, msg := range transcript {
+		if msg == nil {
+			err = fmt.Errorf("tls.certverify: Nil message")
+			return
+		}
 		handshakeContext = append(handshakeContext, msg.Marshal()...)
 	}
 
 	hash, ok := hashMap[cv.alg.hash]
 	if !ok {
-		err = fmt.Errorf("Unsupported hash algorithm")
+		err = fmt.Errorf("tls.certverify: Unsupported hash algorithm")
 		return
 	}
 	h := hash.New()

--- a/handshake-messages.go
+++ b/handshake-messages.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"fmt"
-	"log"
 )
 
 const (
@@ -451,7 +450,7 @@ func (cv *certificateVerifyBody) Verify(publicKey crypto.PublicKey, transcript [
 		return err
 	}
 
-	log.Printf("Digest to be verified: [%d] %x", len(hashedData), hashedData)
+	logf(logTypeHandshake, "Digest to be verified: [%d] %x", len(hashedData), hashedData)
 
 	return verify(cv.alg, publicKey, hashedData, contextCertificateVerify, cv.signature)
 }

--- a/handshake-messages_test.go
+++ b/handshake-messages_test.go
@@ -186,10 +186,10 @@ func TestClientHelloMarshalUnmarshal(t *testing.T) {
 	assertError(t, err, "Unmarshaled a ClientHello below the min length")
 
 	// Test unmarshal failure on wrong version
-	chValid[1] -= 1
+	chValid[1]--
 	_, err = ch.Unmarshal(chValid)
 	assertError(t, err, "Unmarshaled a ClientHello with the wrong version")
-	chValid[1] += 1
+	chValid[1]++
 
 	// Test unmarshal failure on non-empty session ID
 	chValid[34] = 0x04
@@ -272,10 +272,10 @@ func TestServerHelloMarshalUnmarshal(t *testing.T) {
 	assertError(t, err, "Unmarshaled a too-short ServerHello")
 
 	// Test unmarshal failure on wrong version
-	shValid[1] -= 1
+	shValid[1]--
 	_, err = sh.Unmarshal(shValid)
 	assertError(t, err, "Unmarshaled a ServerHello with the wrong version")
-	shValid[1] += 1
+	shValid[1]++
 
 	// Test unmarshal failure on extension list unmarshal failure
 	_, err = sh.Unmarshal(shOverflow)
@@ -294,10 +294,10 @@ func TestFinishedMarshalUnmarshal(t *testing.T) {
 	assertByteEquals(t, out, finValid)
 
 	// Test marshal failure on incorrect data length
-	finValidIn.verifyDataLen -= 1
+	finValidIn.verifyDataLen--
 	out, err = finValidIn.Marshal()
 	assertError(t, err, "Marshaled a Finished with the wrong data length")
-	finValidIn.verifyDataLen += 1
+	finValidIn.verifyDataLen++
 
 	// Test successful unmarshal
 	var fin finishedBody
@@ -308,10 +308,10 @@ func TestFinishedMarshalUnmarshal(t *testing.T) {
 	assertDeepEquals(t, fin, finValidIn)
 
 	// Test unmarshal failure on insufficient data
-	fin.verifyDataLen += 1
+	fin.verifyDataLen++
 	_, err = fin.Unmarshal(finValid)
 	assertError(t, err, "Unmarshaled a Finished with too little data")
-	fin.verifyDataLen -= 1
+	fin.verifyDataLen--
 }
 
 // This one is a little brief because it is just an extensionList

--- a/handshake-messages_test.go
+++ b/handshake-messages_test.go
@@ -82,39 +82,43 @@ var (
 		"470030440220718254f2b3c1cc0fa4c53bf43182f8acbc19" +
 		"04e45ee1a3abdc8bc50a155712b4022010664cc29b80fae9" +
 		"150027726da5b144df764a76007eee2a52b6ae0c995395fb"
+	cert1Bytes, _ = hex.DecodeString(cert1Hex)
+	cert2Bytes, _ = hex.DecodeString(cert2Hex)
+	cert1, _      = x509.ParseCertificate(cert1Bytes)
+	cert2, _      = x509.ParseCertificate(cert2Bytes)
+
 	certValidIn  = certificateBody{certificateRequestContext: []byte{0, 0, 0, 0}}
-	certValidHex = "04000000000002d1308201653082010ba003020102020500" +
-		"a0a0a0a0300a06082a8648ce3d0403023017311530130603" +
-		"550403130c6578616d706c65312e636f6d3022180f303030" +
-		"31303130313030303030305a180f30303031303130313030" +
-		"303030305a3017311530130603550403130c6578616d706c" +
-		"65312e636f6d3059301306072a8648ce3d020106082a8648" +
-		"ce3d030107034200044460e6de2a170e0c7c8d1306c82386" +
-		"db31980bd76647bde9b96055d075fc64ea7d8d3864afcf0f" +
-		"f16da73c68df6880a597303243410016ef2e36f5962584d1" +
-		"87a340303e300e0603551d0f0101ff0404030203a8301306" +
-		"03551d25040c300a06082b0601050507030130170603551d" +
-		"110410300e820c6578616d706c65312e636f6d300a06082a" +
-		"8648ce3d0403020348003045022005937d0bf7a7cb458971" +
-		"5bb83dddd2505335829e6305b75cfeae6f2dcc2230b60221" +
-		"00f6f0e75436cd59b94ceedffb18bcf5bb2f161260a282f7" +
-		"b63d1376e5805c51b6308201643082010ba0030201020205" +
-		"00a0a0a0a0300a06082a8648ce3d04030430173115301306" +
-		"03550403130c6578616d706c65322e636f6d3022180f3030" +
-		"3031303130313030303030305a180f303030313031303130" +
-		"30303030305a3017311530130603550403130c6578616d70" +
-		"6c65322e636f6d3059301306072a8648ce3d020106082a86" +
-		"48ce3d030107034200044460e6de2a170e0c7c8d1306c823" +
-		"86db31980bd76647bde9b96055d075fc64ea7d8d3864afcf" +
-		"0ff16da73c68df6880a597303243410016ef2e36f5962584" +
-		"d187a340303e300e0603551d0f0101ff0404030203a83013" +
-		"0603551d25040c300a06082b060105050703013017060355" +
-		"1d110410300e820c6578616d706c65322e636f6d300a0608" +
-		"2a8648ce3d04030403470030440220718254f2b3c1cc0fa4" +
-		"c53bf43182f8acbc1904e45ee1a3abdc8bc50a155712b402" +
-		"2010664cc29b80fae9150027726da5b144df764a76007eee" +
-		"2a52b6ae0c995395fb"
-	certEmptyHex = "00000000"
+	certValidHex = "04000000000002d7000169308201653082010ba003020102" +
+		"020500a0a0a0a0300a06082a8648ce3d0403023017311530" +
+		"130603550403130c6578616d706c65312e636f6d3022180f" +
+		"30303031303130313030303030305a180f30303031303130" +
+		"313030303030305a3017311530130603550403130c657861" +
+		"6d706c65312e636f6d3059301306072a8648ce3d02010608" +
+		"2a8648ce3d030107034200044460e6de2a170e0c7c8d1306" +
+		"c82386db31980bd76647bde9b96055d075fc64ea7d8d3864" +
+		"afcf0ff16da73c68df6880a597303243410016ef2e36f596" +
+		"2584d187a340303e300e0603551d0f0101ff0404030203a8" +
+		"30130603551d25040c300a06082b06010505070301301706" +
+		"03551d110410300e820c6578616d706c65312e636f6d300a" +
+		"06082a8648ce3d0403020348003045022005937d0bf7a7cb" +
+		"4589715bb83dddd2505335829e6305b75cfeae6f2dcc2230" +
+		"b6022100f6f0e75436cd59b94ceedffb18bcf5bb2f161260" +
+		"a282f7b63d1376e5805c51b6000168308201643082010ba0" +
+		"03020102020500a0a0a0a0300a06082a8648ce3d04030430" +
+		"17311530130603550403130c6578616d706c65322e636f6d" +
+		"3022180f30303031303130313030303030305a180f303030" +
+		"31303130313030303030305a301731153013060355040313" +
+		"0c6578616d706c65322e636f6d3059301306072a8648ce3d" +
+		"020106082a8648ce3d030107034200044460e6de2a170e0c" +
+		"7c8d1306c82386db31980bd76647bde9b96055d075fc64ea" +
+		"7d8d3864afcf0ff16da73c68df6880a597303243410016ef" +
+		"2e36f5962584d187a340303e300e0603551d0f0101ff0404" +
+		"030203a830130603551d25040c300a06082b060105050703" +
+		"0130170603551d110410300e820c6578616d706c65322e63" +
+		"6f6d300a06082a8648ce3d04030403470030440220718254" +
+		"f2b3c1cc0fa4c53bf43182f8acbc1904e45ee1a3abdc8bc5" +
+		"0a155712b4022010664cc29b80fae9150027726da5b144df" +
+		"764a76007eee2a52b6ae0c995395fb"
 
 	// CertificateVerify test cases
 	certVerifyValidIn = certificateVerifyBody{
@@ -333,11 +337,6 @@ func TestEncrypteExtensionsMarshalUnmarshal(t *testing.T) {
 func TestCertificateMarshalUnmarshal(t *testing.T) {
 	// Create a couple of certificates and manually encode
 	certValid, _ := hex.DecodeString(certValidHex)
-	certEmpty, _ := hex.DecodeString(certEmptyHex)
-	cert1Bytes, _ := hex.DecodeString(cert1Hex)
-	cert2Bytes, _ := hex.DecodeString(cert2Hex)
-	cert1, _ := x509.ParseCertificate(cert1Bytes)
-	cert2, _ := x509.ParseCertificate(cert2Bytes)
 	certValidIn.certificateList = []*x509.Certificate{cert1, cert2}
 
 	// Test correctness of handshake type
@@ -386,15 +385,15 @@ func TestCertificateMarshalUnmarshal(t *testing.T) {
 	_, err = cert.Unmarshal(certValid)
 	assertError(t, err, "Unmarshaled a Certificate with truncated certificates")
 	certValid[8] ^= 0xFF
-
-	// Test unmarshal failure on no certificates
-	_, err = cert.Unmarshal(certEmpty)
-	assertError(t, err, "Unmarshaled a Certificate with no certificates")
 }
 
 func TestCertificateVerifyMarshalUnmarshal(t *testing.T) {
 	certVerifyValid, _ := hex.DecodeString(certVerifyValidHex)
-	transcript := []handshakeMessageBody{&chValidIn, &shValidIn}
+
+	chMessage, _ := handshakeMessageFromBody(&chValidIn)
+	shMessage, _ := handshakeMessageFromBody(&shValidIn)
+	transcript := []*handshakeMessage{chMessage, shMessage}
+	nilTranscript := append(transcript, nil)
 	privRSA, err := newSigningKey(signatureAlgorithmRSA)
 	assertNotError(t, err, "failed to generate RSA private key")
 
@@ -426,9 +425,8 @@ func TestCertificateVerifyMarshalUnmarshal(t *testing.T) {
 	assertNotError(t, err, "Failed to sign CertificateVerify")
 
 	// Test sign failure on handshake marshal failure
-	chValidIn.extensions = extListSingleTooLongIn
-	err = certVerifyValidIn.Sign(privRSA, transcript)
-	assertError(t, err, "Signed CertificateVerify despite unmarshal failure")
+	err = certVerifyValidIn.Sign(privRSA, nilTranscript)
+	assertError(t, err, "Signed CertificateVerify despite nil message")
 	chValidIn.extensions = extListValidIn
 
 	// Test sign failure on bad hash algorithm
@@ -446,6 +444,10 @@ func TestCertificateVerifyMarshalUnmarshal(t *testing.T) {
 	// Test verify failure on bad hash algorithm
 	certVerifyValidIn.alg.hash = hashAlgorithm(0)
 	err = certVerifyValidIn.Verify(privRSA.Public(), transcript)
-	assertError(t, err, "Signed CertificateVerify despite bad hash algorithm")
+	assertError(t, err, "Verified CertificateVerify despite bad hash algorithm")
 	certVerifyValidIn.alg.hash = hashAlgorithmSHA256
+
+	// Test veiryf failure on nil message
+	err = certVerifyValidIn.Verify(privRSA.Public(), nilTranscript)
+	assertError(t, err, "Verified CertificateVerify despite nil message")
 }

--- a/log.go
+++ b/log.go
@@ -1,0 +1,52 @@
+package mint
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// We use this environment variable to control logging.  It should be a
+// comma-separated list of log tags (see below) or "*" to enable all logging.
+const logConfigVar = "MINT_LOG"
+
+// Pre-defined log types
+const (
+	logTypeCrypto    = "crypto"
+	logTypeHandshake = "handshake"
+	logTypeIO        = "io"
+)
+
+var (
+	logFunction = log.Printf
+	logAll      = false
+	logSettings = map[string]bool{}
+)
+
+func init() {
+	parseLogEnv(os.Environ())
+}
+
+func parseLogEnv(env []string) {
+	for _, stmt := range env {
+		if strings.HasPrefix(stmt, logConfigVar+"=") {
+			val := stmt[len(logConfigVar)+1:]
+
+			if val == "*" {
+				logAll = true
+			} else {
+				for _, t := range strings.Split(val, ",") {
+					logSettings[t] = true
+				}
+			}
+		}
+	}
+}
+
+func logf(tag string, format string, args ...interface{}) {
+	if logAll || logSettings[tag] {
+		fullFormat := fmt.Sprintf("[%s] %s", tag, format)
+		logFunction(fullFormat, args...)
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,57 @@
+package mint
+
+import (
+	"fmt"
+	"testing"
+)
+
+var logLine = ""
+
+func testLogFunction(format string, v ...interface{}) {
+	logLine = fmt.Sprintf(format, v...)
+}
+
+func TestLogging(t *testing.T) {
+	originalLogFunction := logFunction
+	originalLogAll := logAll
+	originalLogSettings := logSettings
+
+	logAll = false
+	logSettings = map[string]bool{}
+	env := []string{"MINT_LOG=*"}
+	parseLogEnv(env)
+	assert(t, logAll, "Failed to parse wildcard log directive")
+	assert(t, len(logSettings) == 0, "Mistakenly set log settings")
+
+	logAll = false
+	logSettings = map[string]bool{}
+	env = []string{"MINT_LOG=foo,bar"}
+	parseLogEnv(env)
+	assert(t, !logAll, "Mistakenly set logAll")
+	assert(t, logSettings["foo"] && logSettings["bar"], "Failed to parse string log directive")
+
+	logFunction = testLogFunction
+	logAll = false
+	logSettings = map[string]bool{"foo": true}
+
+	// Test that we print matching lines
+	logLine = ""
+	logf("foo", "This is an integer: %d", 1)
+	assertEquals(t, logLine, "[foo] This is an integer: 1")
+
+	// Test that we ignore non-matching lines
+	logLine = ""
+	logf("bar", "This is an integer: %d", 1)
+	assertEquals(t, logLine, "")
+
+	// Test that logAll enables all
+	logAll = true
+	logLine = ""
+	logf("bar", "This is an integer: %d", 1)
+	assertEquals(t, logLine, "[bar] This is an integer: 1")
+
+	// Restore original values for globals
+	logFunction = originalLogFunction
+	logAll = originalLogAll
+	logSettings = originalLogSettings
+}

--- a/record-layer.go
+++ b/record-layer.go
@@ -6,7 +6,6 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"io"
-	"log"
 	"sync"
 )
 
@@ -201,7 +200,7 @@ func (r *recordLayer) ReadRecord() (*tlsPlaintext, error) {
 		}
 	}
 
-	log.Printf("recordLayer.ReadRecord [%d] [%x]", pt.contentType, pt.fragment)
+	logf(logTypeIO, "recordLayer.ReadRecord [%d] [%x]", pt.contentType, pt.fragment)
 
 	r.incrementSequenceNumber()
 	return pt, nil
@@ -226,7 +225,7 @@ func (r *recordLayer) WriteRecordWithPadding(pt *tlsPlaintext, padLen int) error
 	header := []byte{byte(pt.contentType), 0x03, 0x01, byte(length >> 8), byte(length)}
 	record := append(header, pt.fragment...)
 
-	log.Printf("recordLayer.WriteRecord [%d] [%x]", pt.contentType, pt.fragment)
+	logf(logTypeIO, "recordLayer.WriteRecord [%d] [%x]", pt.contentType, pt.fragment)
 
 	r.incrementSequenceNumber()
 	_, err := r.conn.Write(record)

--- a/record-layer_test.go
+++ b/record-layer_test.go
@@ -76,13 +76,14 @@ func TestReadRecord(t *testing.T) {
 	plaintext[0] = 0x15
 
 	// Test failure on wrong version
-	nssCompatMode = false
+	originalAllowWrongVersionNumber := allowWrongVersionNumber
+	allowWrongVersionNumber = false
 	plaintext[2] = 0x02
 	r = newRecordLayer(bytes.NewBuffer(plaintext))
 	pt, err = r.ReadRecord()
 	assertError(t, err, "Failed to reject record with incorrect version")
 	plaintext[2] = 0x01
-	nssCompatMode = true
+	allowWrongVersionNumber = originalAllowWrongVersionNumber
 
 	// Test failure on size too big
 	plaintext[3] = 0xFF

--- a/tls.go
+++ b/tls.go
@@ -58,7 +58,7 @@ func NewListener(inner net.Listener, config *Config) net.Listener {
 // The configuration config must be non-nil and must include
 // at least one certificate or else set GetCertificate.
 func Listen(network, laddr string, config *Config) (net.Listener, error) {
-	if config == nil || !config.ValidForServer() {
+	if config == nil || !config.validForServer() {
 		return nil, errors.New("tls: neither Certificates nor GetCertificate set in Config")
 	}
 	l, err := net.Listen(network, laddr)


### PR DESCRIPTION
With this PR:
* Test coverage is 100% except for `conn.go` and `tls.go`
* `golint` and `go vet` are both clean (except for ciphersuites)
* Logging can be configured with an environment variable (default off) 

Fixes #11 
Fixes #9 