### PR TITLE
Make better self-signed certs

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -13,6 +13,7 @@ import (
 	"encoding/asn1"
 	"fmt"
 	"math/big"
+	"time"
 
 	// Blank includes to ensure hash support
 	_ "crypto/sha1"
@@ -265,9 +266,14 @@ func newSelfSigned(name string, alg signatureAndHashAlgorithm, priv crypto.Signe
 	if !ok {
 		return nil, fmt.Errorf("tls.selfsigned: Unknown signature algorithm")
 	}
+	if len(name) == 0 {
+		return nil, fmt.Errorf("tls.selfsigned: No name provided")
+	}
 
 	template := &x509.Certificate{
 		SerialNumber:       big.NewInt(0xA0A0A0A0),
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().AddDate(0, 0, 1),
 		SignatureAlgorithm: sigAlg,
 		Subject:            pkix.Name{CommonName: name},
 		DNSNames:           []string{name},

--- a/tls_test.go
+++ b/tls_test.go
@@ -166,7 +166,7 @@ func testConnReadNonzeroAndEOF(t *testing.T, delay time.Duration) error {
 			srvCh <- nil
 			return
 		}
-		serverConfig := Config{}
+		serverConfig := Config{ServerName: "example.com"}
 		srv := Server(sconn, &serverConfig)
 		if err := srv.Handshake(); err != nil {
 			fmt.Printf("handshake: %v", err)


### PR DESCRIPTION
- Set notBefore / notAfter
- Require a name to be provided