### PR TITLE
Use correct algorithms in CertVerify signature verification

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -738,7 +738,7 @@ func (c *Conn) clientHandshake() error {
 		logf(logTypeHandshake, "===")
 
 		serverPublicKey := cert.certificateList[0].PublicKey
-		if err = certVerify.Verify(serverPublicKey, transcriptForCertVerify, ctx.resumptionHash); err != nil {
+		if err = certVerify.Verify(serverPublicKey, transcriptForCertVerify, ctx); err != nil {
 			return err
 		}
 
@@ -1132,7 +1132,7 @@ func (c *Conn) serverHandshake() error {
 		certificateVerify := &certificateVerifyBody{
 			alg: signatureAndHashAlgorithm{hashAlgorithmSHA256, signatureAlgorithmRSA},
 		}
-		err = certificateVerify.Sign(privateKey, []*handshakeMessage{chm, shm, eem, certm}, ctx.resumptionHash)
+		err = certificateVerify.Sign(privateKey, []*handshakeMessage{chm, shm, eem, certm}, ctx)
 		if err != nil {
 			return err
 		}

--- a/crypto.go
+++ b/crypto.go
@@ -385,6 +385,7 @@ func verify(alg signatureAndHashAlgorithm, publicKey crypto.PublicKey, data []by
 	switch pub := publicKey.(type) {
 	case *rsa.PublicKey:
 		if allowPKCS1 && alg.signature == signatureAlgorithmRSA {
+			logf(logTypeHandshake, "verifying with PKCS1, hashSize=[%d]", hash.Size())
 			return rsa.VerifyPKCS1v15(pub, hash, digest, sig)
 		}
 


### PR DESCRIPTION
Instead of using the certVerify hash to compute all the hashes in the certVerify computation, use the PRF hash for everything except the final hash.

NB: We should probably just use the pre-hashed transcript from the `cryptoContext` (i.e., `ctx.hX` for some `X`), but rather than figure that out, this patch just uses the right hashes directly.