### PR TITLE
Simplify server handshake

### DIFF
--- a/common.go
+++ b/common.go
@@ -105,11 +105,11 @@ const (
 )
 
 // enum {...} PskKeyExchangeMode;
-type pskKeyExchangeMode uint8
+type PSKKeyExchangeMode uint8
 
 const (
-	pskModeKE    pskKeyExchangeMode = 0
-	pskModeDHEKE pskKeyExchangeMode = 1
+	pskModeKE    PSKKeyExchangeMode = 0
+	pskModeDHEKE PSKKeyExchangeMode = 1
 )
 
 type marshaler interface {

--- a/common.go
+++ b/common.go
@@ -108,8 +108,8 @@ const (
 type PSKKeyExchangeMode uint8
 
 const (
-	pskModeKE    PSKKeyExchangeMode = 0
-	pskModeDHEKE PSKKeyExchangeMode = 1
+	PSKModeKE    PSKKeyExchangeMode = 0
+	PSKModeDHEKE PSKKeyExchangeMode = 1
 )
 
 type marshaler interface {

--- a/common_test.go
+++ b/common_test.go
@@ -49,7 +49,7 @@ func assertNotByteEquals(t *testing.T, a []byte, b []byte) {
 
 func assertDeepEquals(t *testing.T, a interface{}, b interface{}) {
 	if !reflect.DeepEqual(a, b) {
-		assert(t, false, fmt.Sprintf("%v != %v", a, b))
+		assert(t, false, fmt.Sprintf("%+v != %+v", a, b))
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -166,8 +166,8 @@ var (
 	defaultTicketLen = 16
 
 	defaultPSKModes = []PSKKeyExchangeMode{
-		pskModeKE,
-		pskModeDHEKE,
+		PSKModeKE,
+		PSKModeDHEKE,
 	}
 )
 

--- a/conn.go
+++ b/conn.go
@@ -21,6 +21,7 @@ type PreSharedKey struct {
 	IsResumption bool
 	Identity     []byte
 	Key          []byte
+	NextProto    string
 }
 
 // Config is the struct used to pass configuration settings to a TLS client or
@@ -60,6 +61,7 @@ type Config struct {
 	SendSessionTickets bool
 	TicketLifetime     uint32
 	TicketLen          int
+	AllowEarlyData     bool
 
 	// Shared fields
 	CipherSuites     []CipherSuite
@@ -67,6 +69,7 @@ type Config struct {
 	SignatureSchemes []SignatureScheme
 	NextProtos       []string
 	PSKs             map[string]PreSharedKey
+	PSKModes         []PSKKeyExchangeMode
 
 	// Hidden fields (used for caching in convenient form)
 	enabledSuite  map[CipherSuite]bool
@@ -99,6 +102,9 @@ func (c *Config) Init(isClient bool) error {
 	}
 	if c.PSKs == nil {
 		c.PSKs = map[string]PreSharedKey{}
+	}
+	if len(c.PSKModes) == 0 {
+		c.PSKModes = defaultPSKModes
 	}
 
 	// If there is no certificate, generate one
@@ -158,6 +164,11 @@ var (
 	}
 
 	defaultTicketLen = 16
+
+	defaultPSKModes = []PSKKeyExchangeMode{
+		pskModeKE,
+		pskModeDHEKE,
+	}
 )
 
 type ConnectionState struct {
@@ -491,6 +502,7 @@ func (c *Conn) clientHandshake() error {
 		Groups:           c.config.Groups,
 		SignatureSchemes: c.config.SignatureSchemes,
 		PSKs:             c.config.PSKs,
+		PSKModes:         c.config.PSKModes,
 	}
 	opts := connectionOptions{
 		ServerName: c.config.ServerName,
@@ -634,10 +646,11 @@ func (c *Conn) serverHandshake() error {
 		Groups:           c.config.Groups,
 		SignatureSchemes: c.config.SignatureSchemes,
 		PSKs:             c.config.PSKs,
+		AllowEarlyData:   c.config.AllowEarlyData,
 		NextProtos:       c.config.NextProtos,
 		Certificates:     c.config.Certificates,
 	}
-	shm, serverFirstFlight, acceptEarlyData, err := h.HandleClientHello(chm, caps)
+	shm, serverFirstFlight, err := h.HandleClientHello(chm, caps)
 	if err != nil {
 		return err
 	}
@@ -668,7 +681,7 @@ func (c *Conn) serverHandshake() error {
 	}
 
 	// Handle early data that the client sends
-	if acceptEarlyData {
+	if h.Params.UsingEarlyData {
 		logf(logTypeHandshake, "[server] Processing early data")
 
 		// Compute early handshake / traffic keys from pskSecret
@@ -725,7 +738,7 @@ func (c *Conn) serverHandshake() error {
 	// Even if we reject early data, the client might still send it.  We need
 	// to read past any records that don't decrypt until we hit the next
 	// handshake message.
-	if !acceptEarlyData {
+	if !h.Params.UsingEarlyData {
 		logf(logTypeHandshake, "[server] Rejecting early data; reading past it")
 		for {
 			pt, err := c.in.ReadRecord()

--- a/conn_test.go
+++ b/conn_test.go
@@ -365,8 +365,6 @@ func TestResumption(t *testing.T) {
 
 	assertDeepEquals(t, client2.handshake.ConnectionParams(), server2.handshake.ConnectionParams())
 	assertContextEquals(t, client2.handshake.CryptoContext(), server2.handshake.CryptoContext())
-
-	// TODO re-enable assertByteEquals(t, client2.handshake.CryptoContext().SS, client1.handshake.CryptoContext().resumptionSecret)
 }
 
 func Test0xRTT(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -167,9 +167,10 @@ var (
 	}
 
 	pskConfig = &Config{
-		ServerName:   serverName,
-		CipherSuites: []CipherSuite{TLS_AES_128_GCM_SHA256},
-		PSKs:         psks,
+		ServerName:     serverName,
+		CipherSuites:   []CipherSuite{TLS_AES_128_GCM_SHA256},
+		PSKs:           psks,
+		AllowEarlyData: true,
 	}
 
 	pskECDHEConfig = &Config{

--- a/conn_test.go
+++ b/conn_test.go
@@ -278,6 +278,7 @@ func TestBasicFlows(t *testing.T) {
 
 		<-done
 
+		assertDeepEquals(t, client.handshake.ConnectionParams(), server.handshake.ConnectionParams())
 		assertContextEquals(t, client.handshake.CryptoContext(), server.handshake.CryptoContext())
 	}
 }
@@ -300,6 +301,9 @@ func TestPSKFlows(t *testing.T) {
 		assertNotError(t, err, "Client failed handshake")
 
 		<-done
+
+		assertDeepEquals(t, client.handshake.ConnectionParams(), server.handshake.ConnectionParams())
+		assert(t, client.handshake.ConnectionParams().UsingPSK, "Session did not use the provided PSK")
 
 		assertContextEquals(t, client.handshake.CryptoContext(), server.handshake.CryptoContext())
 	}
@@ -327,6 +331,7 @@ func TestResumption(t *testing.T) {
 	client1.Read(nil)
 	<-done
 
+	assertDeepEquals(t, client1.handshake.ConnectionParams(), server1.handshake.ConnectionParams())
 	assertContextEquals(t, client1.handshake.CryptoContext(), server1.handshake.CryptoContext())
 	assertEquals(t, len(clientConfig.PSKs), 1)
 	assertEquals(t, len(serverConfig.PSKs), 1)
@@ -358,6 +363,7 @@ func TestResumption(t *testing.T) {
 	client2.Read(nil)
 	<-done
 
+	assertDeepEquals(t, client2.handshake.ConnectionParams(), server2.handshake.ConnectionParams())
 	assertContextEquals(t, client2.handshake.CryptoContext(), server2.handshake.CryptoContext())
 
 	// TODO re-enable assertByteEquals(t, client2.handshake.CryptoContext().SS, client1.handshake.CryptoContext().resumptionSecret)
@@ -385,6 +391,8 @@ func Test0xRTT(t *testing.T) {
 	<-done
 
 	assertContextEquals(t, client.handshake.CryptoContext(), server.handshake.CryptoContext())
+	assertDeepEquals(t, client.handshake.ConnectionParams(), server.handshake.ConnectionParams())
+	assert(t, client.handshake.ConnectionParams().UsingEarlyData, "Session did not negotiate early data")
 	assertByteEquals(t, client.earlyData, server.readBuffer)
 }
 

--- a/extensions.go
+++ b/extensions.go
@@ -429,7 +429,7 @@ func (psk preSharedKeyExtension) HasIdentity(id []byte) ([]byte, bool) {
 //     PskKeyExchangeMode ke_modes<1..255>;
 // } PskKeyExchangeModes;
 type pskKeyExchangeModesExtension struct {
-	KEModes []pskKeyExchangeMode `tls:"head=1,min=1"`
+	KEModes []PSKKeyExchangeMode `tls:"head=1,min=1"`
 }
 
 func (pkem pskKeyExchangeModesExtension) Type() extensionType {

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -204,8 +204,8 @@ var validExtensionTestCases = map[extensionType]struct {
 		blank: &pskKeyExchangeModesExtension{},
 		unmarshaled: &pskKeyExchangeModesExtension{
 			KEModes: []PSKKeyExchangeMode{
-				pskModeKE,
-				pskModeDHEKE,
+				PSKModeKE,
+				PSKModeDHEKE,
 			},
 		},
 		marshaledHex: "020001",

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -203,7 +203,7 @@ var validExtensionTestCases = map[extensionType]struct {
 	extensionTypePSKKeyExchangeModes: {
 		blank: &pskKeyExchangeModesExtension{},
 		unmarshaled: &pskKeyExchangeModesExtension{
-			KEModes: []pskKeyExchangeMode{
+			KEModes: []PSKKeyExchangeMode{
 				pskModeKE,
 				pskModeDHEKE,
 			},

--- a/handshake.go
+++ b/handshake.go
@@ -2,8 +2,6 @@ package mint
 
 import (
 	"bytes"
-	"crypto"
-	"crypto/x509"
 	"fmt"
 )
 
@@ -14,9 +12,13 @@ type capabilities struct {
 	SignatureSchemes []SignatureScheme
 	PSKs             map[string]PreSharedKey
 
+	// For client
+	PSKModes []PSKKeyExchangeMode
+
 	// For server
-	NextProtos   []string
-	Certificates []*Certificate
+	NextProtos     []string
+	Certificates   []*Certificate
+	AllowEarlyData bool
 }
 
 type connectionOptions struct {
@@ -25,8 +27,19 @@ type connectionOptions struct {
 	EarlyData  []byte
 }
 
+type connectionParameters struct {
+	UsingPSK       bool
+	UsingDH        bool
+	UsingEarlyData bool
+
+	CipherSuite CipherSuite
+	ServerName  string
+	ALPN        string
+}
+
 type handshake interface {
 	IsClient() bool
+	ConnectionParams() connectionParameters
 	CryptoContext() *cryptoContext
 	InboundKeys() (aeadFactory, keySet)
 	OutboundKeys() (aeadFactory, keySet)
@@ -87,6 +100,7 @@ type clientHandshake struct {
 
 	PSK     []byte
 	Context cryptoContext
+	Params  connectionParameters
 
 	AuthCertificate func(chain []certificateEntry) error
 
@@ -100,6 +114,10 @@ func (h *clientHandshake) IsClient() bool {
 
 func (h *clientHandshake) CryptoContext() *cryptoContext {
 	return &h.Context
+}
+
+func (h clientHandshake) ConnectionParams() connectionParameters {
+	return h.Params
 }
 
 func (h *clientHandshake) InboundKeys() (aeadFactory, keySet) {
@@ -158,6 +176,7 @@ func (h *clientHandshake) CreateClientHello(opts connectionOptions, caps capabil
 	sni := serverNameExtension(opts.ServerName)
 	sg := supportedGroupsExtension{Groups: caps.Groups}
 	sa := signatureAlgorithmsExtension{Algorithms: caps.SignatureSchemes}
+	kem := pskKeyExchangeModesExtension{KEModes: caps.PSKModes}
 
 	// Application Layer Protocol Negotiation
 	var alpn *alpnExtension
@@ -173,7 +192,7 @@ func (h *clientHandshake) CreateClientHello(opts connectionOptions, caps capabil
 	if err != nil {
 		return nil, err
 	}
-	for _, ext := range []extensionBody{&sv, &sni, &ks, &sg, &sa} {
+	for _, ext := range []extensionBody{&sv, &sni, &ks, &sg, &sa, &kem} {
 		err := ch.extensions.Add(ext)
 		if err != nil {
 			return nil, err
@@ -380,6 +399,7 @@ func (h *clientHandshake) HandleServerFirstFlight(transcript []*handshakeMessage
 
 type serverHandshake struct {
 	Context cryptoContext
+	Params  connectionParameters
 }
 
 func (h *serverHandshake) IsClient() bool {
@@ -388,6 +408,10 @@ func (h *serverHandshake) IsClient() bool {
 
 func (h *serverHandshake) CryptoContext() *cryptoContext {
 	return &h.Context
+}
+
+func (h serverHandshake) ConnectionParams() connectionParameters {
+	return h.Params
 }
 
 func (h *serverHandshake) CreateKeyUpdate(requestUpdate keyUpdateRequest) (*handshakeMessage, error) {
@@ -410,11 +434,11 @@ func (h *serverHandshake) OutboundKeys() (aeadFactory, keySet) {
 	return h.Context.params.cipher, h.Context.serverTrafficKeys
 }
 
-func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabilities) (*handshakeMessage, []*handshakeMessage, bool, error) {
+func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabilities) (*handshakeMessage, []*handshakeMessage, error) {
 	ch := &clientHelloBody{}
 	_, err := ch.Unmarshal(chm.body)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	supportedVersions := new(supportedVersionsExtension)
@@ -425,196 +449,98 @@ func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabili
 	clientPSK := &preSharedKeyExtension{handshakeType: handshakeTypeClientHello}
 	clientEarlyData := &earlyDataExtension{}
 	clientALPN := new(alpnExtension)
+	clientPSKModes := new(pskKeyExchangeModesExtension)
 
 	gotSupportedVersions := ch.extensions.Find(supportedVersions)
 	gotServerName := ch.extensions.Find(serverName)
 	gotSupportedGroups := ch.extensions.Find(supportedGroups)
 	gotSignatureAlgorithms := ch.extensions.Find(signatureAlgorithms)
-	gotKeyShares := ch.extensions.Find(clientKeyShares)
-	gotPSK := ch.extensions.Find(clientPSK)
 	gotEarlyData := ch.extensions.Find(clientEarlyData)
-	gotALPN := ch.extensions.Find(clientALPN)
-
-	// TODO: Factor out these negotiation blocks into functions that can get tested individually
-	// TODO: Maybe make a "session parameters" struct that we can store alongside PSKs
+	ch.extensions.Find(clientKeyShares)
+	ch.extensions.Find(clientPSK)
+	ch.extensions.Find(clientALPN)
+	ch.extensions.Find(clientPSKModes)
 
 	// If the client didn't send supportedVersions or doesn't support 1.3,
 	// then we're done here.
 	if !gotSupportedVersions {
 		logf(logTypeHandshake, "[server] Client did not send supported_versions")
-		return nil, nil, false, fmt.Errorf("tls.server: Client did not send supported_versions")
+		return nil, nil, fmt.Errorf("tls.server: Client did not send supported_versions")
 	}
-	clientSupportsSameVersion := false
-	for _, version := range supportedVersions.Versions {
-		logf(logTypeHandshake, "[server] version offered by client [%04x] <> [%04x]", version, supportedVersion)
-		clientSupportsSameVersion = (version == supportedVersion)
-		if clientSupportsSameVersion {
-			break
-		}
-	}
-	if !clientSupportsSameVersion {
+	versionOK := versionNegotiation(supportedVersions.Versions, []uint16{supportedVersion})
+	if !versionOK {
 		logf(logTypeHandshake, "[server] Client does not support the same version")
-		return nil, nil, false, fmt.Errorf("tls.server: Client does not support the same version")
+		return nil, nil, fmt.Errorf("tls.server: Client does not support the same version")
 	}
 
-	// Find the ALPN extension and select a protocol
-	var serverALPN *alpnExtension
-	if gotALPN {
-		logf(logTypeHandshake, "[server] Got ALPN offer: %v", clientALPN.protocols)
-		for _, proto := range clientALPN.protocols {
-			for _, serverProto := range caps.NextProtos {
-				if proto != serverProto {
-					continue
-				}
+	// Figure out if we can do DH
+	canDoDH, dhGroup, dhPub, dhSecret := dhNegotiation(clientKeyShares.shares, caps.Groups)
 
-				logf(logTypeHandshake, "[server] Sending ALPN value %v", proto)
-				serverALPN = &alpnExtension{protocols: []string{proto}}
-				break
-			}
-
-			if serverALPN != nil {
-				break
-			}
+	// Figure out if we can do PSK
+	canDoPSK := false
+	var selectedPSK int
+	var psk *PreSharedKey
+	var ctx cryptoContext
+	if len(clientPSK.identities) > 0 {
+		chTrunc, err := ch.Truncated()
+		if err != nil {
+			return nil, nil, err
+		}
+		canDoPSK, selectedPSK, psk, ctx, err = pskNegotiation(clientPSK.identities, clientPSK.binders, chTrunc, caps.PSKs)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
+	h.Context = ctx
 
-	// Find pre_shared_key extension and look it up
-	var serverPSK *preSharedKeyExtension
-	var pskSuite CipherSuite
-	usingPSK := false
-	if gotPSK {
-		logf(logTypeHandshake, "[server] Got PSK extension; processing")
-		for _, id := range clientPSK.identities {
-			logf(logTypeHandshake, "[server] Client provided PSK identity %x", id)
-		}
+	// Figure out if we actually should do DH / PSK
+	h.Params.UsingDH, h.Params.UsingPSK = pskModeNegotiation(canDoDH, canDoPSK, clientPSKModes.KEModes)
 
-		for i, id := range clientPSK.identities {
-			for _, key := range caps.PSKs {
-				if !bytes.Equal(id.Identity, key.Identity) {
-					continue
-				}
-
-				// Verify the binder
-				h.Context.preInit(key)
-				trunc, err := ch.Truncated()
-				if err != nil {
-					return nil, nil, false, err
-				}
-
-				truncHash := h.Context.params.hash.New()
-				truncHash.Write(trunc)
-
-				binder := h.Context.computeFinishedData(h.Context.binderKey, truncHash.Sum(nil))
-				if !bytes.Equal(binder, clientPSK.binders[i].Binder) {
-					logf(logTypeHandshake, "Binder check failed identity %x", key.Identity)
-					return nil, nil, false, fmt.Errorf("PSK binder check failed")
-				}
-
-				logf(logTypeHandshake, "Using PSK identity %x", key.Identity)
-				usingPSK = true
-				pskSuite = key.CipherSuite
-
-				serverPSK = &preSharedKeyExtension{
-					handshakeType:    handshakeTypeServerHello,
-					selectedIdentity: uint16(i),
-				}
-
-				// If we're going to need to receive early data, prepare the relevant keys
-				if gotEarlyData {
-					h.Context.earlyUpdateWithClientHello(chm)
-				}
-
-				break
-			}
-
-			if usingPSK {
-				break
-			}
-		}
+	// If we've got no entropy to make keys from, fail
+	if !h.Params.UsingDH && !h.Params.UsingPSK {
+		logf(logTypeHandshake, "[server] Neither DH nor PSK negotiated")
+		return nil, nil, fmt.Errorf("Neither DH nor PSK negotiated")
 	}
 
-	// If we're not using a PSK mode, then we need to have certain extensions
-	if usingPSK && (!gotServerName || !gotSupportedGroups || !gotSignatureAlgorithms) {
-		logf(logTypeHandshake, "[server] Insufficient extensions (%v %v %v %v)",
-			gotServerName, gotSupportedGroups, gotSignatureAlgorithms, gotKeyShares)
-		return nil, nil, false, fmt.Errorf("tls.server: Missing extension in ClientHello")
-	}
+	var cert *Certificate
+	var certScheme SignatureScheme
+	if !h.Params.UsingPSK {
+		psk = nil
+		h.Context = cryptoContext{}
 
-	// Reject early data if we haven't found the PSK
-	acceptEarlyData := gotEarlyData && usingPSK
-
-	// Find key_share extension and do key agreement
-	var serverKeyShare *keyShareExtension
-	var dhSecret []byte
-	if gotKeyShares {
-		logf(logTypeHandshake, "[server] Got KeyShare extension; processing")
-		for _, share := range clientKeyShares.shares {
-			for _, group := range caps.Groups {
-				if group != share.Group {
-					continue
-				}
-
-				pub, priv, err := newKeyShare(share.Group)
-				if err != nil {
-					return nil, nil, false, err
-				}
-
-				dhSecret, err = keyAgreement(share.Group, share.KeyExchange, priv)
-				serverKeyShare = &keyShareExtension{
-					handshakeType: handshakeTypeServerHello,
-					shares:        []keyShareEntry{keyShareEntry{Group: share.Group, KeyExchange: pub}},
-				}
-				if err != nil {
-					return nil, nil, false, err
-				}
-				break
-			}
-
-			if dhSecret != nil {
-				break
-			}
-		}
-	}
-
-	// At this point, we either need a PSK or DH (or both) to proceed
-	// TODO: Send a HelloRetryRequest here
-	if !usingPSK && (dhSecret == nil) {
-		logf(logTypeHandshake, "[server] Can't proceed without either PSK or DH")
-		return nil, nil, false, fmt.Errorf("[server] Can't proceed without either PSK or DH")
-	}
-
-	// Pick a ciphersuite.  If we're using a PSK, we just need to verify that the
-	// preset suite is offered
-	var chosenSuite CipherSuite
-	foundCipherSuite := false
-	for _, suite := range ch.cipherSuites {
-		if usingPSK && (suite == pskSuite) {
-			chosenSuite = suite
-			foundCipherSuite = true
-			break
-		} else if usingPSK {
-			continue
+		// If we're not using a PSK mode, then we need to have certain extensions
+		if !gotServerName || !gotSupportedGroups || !gotSignatureAlgorithms {
+			logf(logTypeHandshake, "[server] Insufficient extensions (%v %v %v)",
+				gotServerName, gotSupportedGroups, gotSignatureAlgorithms)
+			return nil, nil, fmt.Errorf("tls.server: Missing extension in ClientHello")
 		}
 
-		for _, serverSuite := range caps.CipherSuites {
-			if suite == serverSuite {
-				chosenSuite = suite
-				foundCipherSuite = true
-				break
-			}
-		}
-
-		if foundCipherSuite {
-			break
-		}
+		// Select a certificate
+		cert, certScheme, err = certificateSelection(string(*serverName), signatureAlgorithms.Algorithms, caps.Certificates)
 	}
 
-	logf(logTypeCrypto, "Supported Client suites [%v]", ch.cipherSuites)
-	if !foundCipherSuite {
-		logf(logTypeHandshake, "No acceptable ciphersuites")
-		return nil, nil, false, fmt.Errorf("tls.server: No acceptable ciphersuites")
+	if !h.Params.UsingDH {
+		dhSecret = nil
 	}
-	logf(logTypeHandshake, "[server] Chose CipherSuite %x", chosenSuite)
+
+	// Figure out if we're going to do early data
+	h.Params.UsingEarlyData = earlyDataNegotiation(h.Params.UsingPSK, gotEarlyData, caps.AllowEarlyData)
+
+	if h.Params.UsingEarlyData {
+		h.Context.earlyUpdateWithClientHello(chm)
+	}
+
+	// Select a ciphersuite
+	chosenSuite, err := cipherSuiteNegotiation(psk, ch.cipherSuites, caps.CipherSuites)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Select a next protocol
+	chosenALPN, err := alpnNegotiation(psk, clientALPN.protocols, caps.NextProtos)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Create the ServerHello
 	sh := &serverHelloBody{
@@ -623,153 +549,93 @@ func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabili
 	}
 	_, err = prng.Read(sh.Random[:])
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
-	if dhSecret != nil {
-		logf(logTypeHandshake, "[server] sending key share extension")
-		err = sh.Extensions.Add(serverKeyShare)
+	if h.Params.UsingDH {
+		logf(logTypeHandshake, "[server] sending DH extension")
+		err = sh.Extensions.Add(&keyShareExtension{
+			handshakeType: handshakeTypeServerHello,
+			shares:        []keyShareEntry{keyShareEntry{Group: dhGroup, KeyExchange: dhPub}},
+		})
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
-	} else {
-		logf(logTypeHandshake, "[server] not sending key share extension; deleting DH secret")
-		dhSecret = nil
 	}
-	if usingPSK {
+	if h.Params.UsingPSK {
 		logf(logTypeHandshake, "[server] sending PSK extension")
-		err = sh.Extensions.Add(serverPSK)
+		err = sh.Extensions.Add(&preSharedKeyExtension{
+			handshakeType:    handshakeTypeServerHello,
+			selectedIdentity: uint16(selectedPSK),
+		})
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 	}
 	logf(logTypeHandshake, "[server] Done creating ServerHello")
 
 	shm, err := handshakeMessageFromBody(sh)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	// Crank up the crypto context
 	err = h.Context.init(sh.CipherSuite, chm)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	err = h.Context.updateWithServerHello(shm, dhSecret)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	// Send an EncryptedExtensions message (even if it's empty)
 	eeList := extensionList{}
-	if serverALPN != nil {
+	if chosenALPN != "" {
 		logf(logTypeHandshake, "[server] sending ALPN extension")
-		err = eeList.Add(serverALPN)
+		err = eeList.Add(&alpnExtension{protocols: []string{chosenALPN}})
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 	}
-	if acceptEarlyData {
+	if h.Params.UsingEarlyData {
 		logf(logTypeHandshake, "[server] sending EDI extension")
 		err = eeList.Add(&earlyDataExtension{})
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 	}
 	ee := &encryptedExtensionsBody{eeList}
 	eem, err := handshakeMessageFromBody(ee)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	transcript := []*handshakeMessage{eem}
 
 	// Authenticate with a certificate if required
-	if !usingPSK {
-		// Select a certificate
-		var privateKey crypto.Signer
-		var chain []*x509.Certificate
-		foundCert := false
-		for _, cert := range caps.Certificates {
-			for _, name := range cert.Chain[0].DNSNames {
-				if name == string(*serverName) {
-					foundCert = true
-					chain = cert.Chain
-					privateKey = cert.PrivateKey
-				}
-			}
-		}
-
-		// If there's no match, take the first certificate provided
-		if !foundCert && len(caps.Certificates) > 0 {
-			chain = caps.Certificates[0].Chain
-			privateKey = caps.Certificates[0].PrivateKey
-		} else if len(caps.Certificates) == 0 {
-			return nil, nil, false, fmt.Errorf("No certificate available for the requested name [%s]", *serverName)
-		}
-
-		// Select a signature scheme from among those offered by the client
-		var sigAlg SignatureScheme
-		foundSigAlg := false
-		for _, alg := range signatureAlgorithms.Algorithms {
-
-			valid := schemeValidForKey(alg, privateKey)
-			if !valid {
-				continue
-			}
-
-			enabled := false
-			for _, scheme := range caps.SignatureSchemes {
-				if alg == scheme {
-					enabled = true
-					break
-				}
-			}
-			if !enabled {
-				continue
-			}
-
-			sigAlg = alg
-			foundSigAlg = true
-			break
-		}
-		if !foundSigAlg {
-			return nil, nil, false, fmt.Errorf("No signature schemes available for this client and certificate")
-		}
-		logf(logTypeHandshake, "Computing CertificateVerify with scheme %04x", sigAlg)
-
-		// If there's no name match, use the first in the list or fail
-		if chain == nil {
-			if len(caps.Certificates) > 0 {
-				chain = caps.Certificates[0].Chain
-				privateKey = caps.Certificates[0].PrivateKey
-			} else {
-				return nil, nil, false, fmt.Errorf("No certificate found for %s", string(*serverName))
-			}
-		}
-
+	if !h.Params.UsingPSK {
 		// Create and send Certificate, CertificateVerify
-		// TODO Certificate selection based on ClientHello
 		certificate := &certificateBody{
-			certificateList: make([]certificateEntry, len(chain)),
+			certificateList: make([]certificateEntry, len(cert.Chain)),
 		}
-		for i, cert := range chain {
-			certificate.certificateList[i] = certificateEntry{certData: cert}
+		for i, entry := range cert.Chain {
+			certificate.certificateList[i] = certificateEntry{certData: entry}
 		}
 		certm, err := handshakeMessageFromBody(certificate)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 
-		certificateVerify := &certificateVerifyBody{Algorithm: sigAlg}
-		logf(logTypeHandshake, "%04x %v", sigAlg, h.Context.params.hash)
-		err = certificateVerify.Sign(privateKey, []*handshakeMessage{chm, shm, eem, certm}, h.Context)
+		certificateVerify := &certificateVerifyBody{Algorithm: certScheme}
+		logf(logTypeHandshake, "Creating CertVerify: %04x %v", certScheme, h.Context.params.hash)
+		err = certificateVerify.Sign(cert.PrivateKey, []*handshakeMessage{chm, shm, eem, certm}, h.Context)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 		certvm, err := handshakeMessageFromBody(certificateVerify)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 
 		transcript = append(transcript, []*handshakeMessage{certm, certvm}...)
@@ -778,16 +644,16 @@ func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabili
 	// Crank the crypto context
 	err = h.Context.updateWithServerFirstFlight(transcript)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 	fm, err := handshakeMessageFromBody(h.Context.serverFinished)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 
 	transcript = append(transcript, fm)
 
-	return shm, transcript, acceptEarlyData, nil
+	return shm, transcript, nil
 }
 
 func (h *serverHandshake) HandleClientSecondFlight(transcript []*handshakeMessage, finishedMessage *handshakeMessage) error {

--- a/handshake.go
+++ b/handshake.go
@@ -495,7 +495,7 @@ func (h *serverHandshake) HandleClientHello(chm *handshakeMessage, caps capabili
 		logf(logTypeHandshake, "[server] Client did not send supported_versions")
 		return nil, nil, fmt.Errorf("tls.server: Client did not send supported_versions")
 	}
-	versionOK := versionNegotiation(supportedVersions.Versions, []uint16{supportedVersion})
+	versionOK, _ := versionNegotiation(supportedVersions.Versions, []uint16{supportedVersion})
 	if !versionOK {
 		logf(logTypeHandshake, "[server] Client does not support the same version")
 		return nil, nil, fmt.Errorf("tls.server: Client does not support the same version")

--- a/log.go
+++ b/log.go
@@ -13,9 +13,10 @@ const logConfigVar = "MINT_LOG"
 
 // Pre-defined log types
 const (
-	logTypeCrypto    = "crypto"
-	logTypeHandshake = "handshake"
-	logTypeIO        = "io"
+	logTypeCrypto      = "crypto"
+	logTypeHandshake   = "handshake"
+	logTypeNegotiation = "negotiation"
+	logTypeIO          = "io"
 )
 
 var (

--- a/negotiation.go
+++ b/negotiation.go
@@ -1,0 +1,172 @@
+package mint
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func versionNegotiation(offered, supported []uint16) (bool, uint16) {
+	for _, offeredVersion := range offered {
+		for _, supportedVersion := range supported {
+			logf(logTypeHandshake, "[server] version offered by client [%04x] <> [%04x]", offeredVersion, supportedVersion)
+			if offeredVersion == supportedVersion {
+				// XXX: Should probably be highest supported version, but for now, we
+				// only support one version, so it doesn't really matter.
+				return true, offeredVersion
+			}
+		}
+	}
+
+	return false, 0
+}
+
+func dhNegotiation(keyShares []keyShareEntry, groups []NamedGroup) (bool, NamedGroup, []byte, []byte) {
+	for _, share := range keyShares {
+		for _, group := range groups {
+			if group != share.Group {
+				continue
+			}
+
+			pub, priv, err := newKeyShare(share.Group)
+			if err != nil {
+				// If we encounter an error, just keep looking
+				continue
+			}
+
+			dhSecret, err := keyAgreement(share.Group, share.KeyExchange, priv)
+			if err != nil {
+				// If we encounter an error, just keep looking
+				continue
+			}
+
+			return true, group, pub, dhSecret
+		}
+	}
+
+	return false, 0, nil, nil
+}
+
+func pskNegotiation(identities []pskIdentity, binders []pskBinderEntry, chTrunc []byte, psks map[string]PreSharedKey) (bool, int, *PreSharedKey, cryptoContext, error) {
+	logf(logTypeNegotiation, "Negotiating PSK offered=[%d] supported=[%d]", len(identities), len(psks))
+	for i, id := range identities {
+		for _, key := range psks {
+			logf(logTypeNegotiation, "Identity check [%x] <> [%x]", id.Identity, key.Identity)
+			if !bytes.Equal(id.Identity, key.Identity) {
+				continue
+			}
+
+			ctx := cryptoContext{}
+			ctx.preInit(key)
+
+			truncHash := ctx.params.hash.New()
+			truncHash.Write(chTrunc)
+			binder := ctx.computeFinishedData(ctx.binderKey, truncHash.Sum(nil))
+			if !bytes.Equal(binder, binders[i].Binder) {
+				logf(logTypeNegotiation, "Binder check failed for identity %x", key.Identity)
+				return false, 0, nil, cryptoContext{}, fmt.Errorf("Binder check failed identity %x", key.Identity)
+			}
+
+			logf(logTypeNegotiation, "Using PSK with identity %x", key.Identity)
+			return true, i, &key, ctx, nil
+		}
+	}
+
+	logf(logTypeNegotiation, "Failed to find a usable PSK")
+	return false, 0, nil, cryptoContext{}, nil
+}
+
+func pskModeNegotiation(canDoDH, canDoPSK bool, modes []PSKKeyExchangeMode) (bool, bool) {
+	logf(logTypeNegotiation, "Negotiating PSK modes [%v] [%v] [%+v]", canDoDH, canDoPSK, modes)
+	dhAllowed := false
+	dhRequired := true
+	for _, mode := range modes {
+		dhAllowed = dhAllowed || (mode == PSKModeDHEKE)
+		dhRequired = dhRequired && (mode == PSKModeDHEKE)
+	}
+
+	// Use PSK if we can meet DH requirement and modes were provided
+	usingPSK := canDoPSK && (!dhRequired || canDoDH) && (len(modes) > 0)
+
+	// Use DH if allowed
+	usingDH := canDoDH && (dhAllowed || !usingPSK)
+
+	logf(logTypeNegotiation, "Results of PSK mode negotiation: usingDH=[%v] usingPSK=[%v]", usingDH, usingPSK)
+	return usingDH, usingPSK
+}
+
+func certificateSelection(serverName string, signatureSchemes []SignatureScheme, certs []*Certificate) (*Certificate, SignatureScheme, error) {
+	// Select for server name
+	candidatesByName := []*Certificate{}
+	for _, cert := range certs {
+		for _, name := range cert.Chain[0].DNSNames {
+			if len(serverName) > 0 && name == serverName {
+				candidatesByName = append(candidatesByName, cert)
+			}
+		}
+	}
+
+	if len(candidatesByName) == 0 {
+		return nil, 0, fmt.Errorf("No certificates available for server name")
+	}
+
+	// Select for signature scheme
+	for _, cert := range candidatesByName {
+		for _, scheme := range signatureSchemes {
+			if !schemeValidForKey(scheme, cert.PrivateKey) {
+				continue
+			}
+
+			return cert, scheme, nil
+		}
+	}
+
+	return nil, 0, fmt.Errorf("No certificates compatible with signature schemes")
+}
+
+func earlyDataNegotiation(usingPSK, gotEarlyData, allowEarlyData bool) bool {
+	usingEarlyData := gotEarlyData && usingPSK && allowEarlyData
+	logf(logTypeNegotiation, "Early data negotiation (%v, %v, %v) => %v", usingPSK, gotEarlyData, allowEarlyData, usingEarlyData)
+	return usingEarlyData
+}
+
+func cipherSuiteNegotiation(psk *PreSharedKey, offered, supported []CipherSuite) (CipherSuite, error) {
+	for _, s1 := range offered {
+		if psk != nil {
+			if s1 == psk.CipherSuite {
+				return s1, nil
+			}
+			continue
+		}
+
+		for _, s2 := range supported {
+			if s1 == s2 {
+				return s1, nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("No overlap between offered and supproted ciphersuites (psk? [%v])", psk != nil)
+}
+
+func alpnNegotiation(psk *PreSharedKey, offered, supported []string) (string, error) {
+	for _, p1 := range offered {
+		if psk != nil {
+			if p1 != psk.NextProto {
+				continue
+			}
+		}
+
+		for _, p2 := range supported {
+			if p1 == p2 {
+				return p1, nil
+			}
+		}
+	}
+
+	// If the client offers ALPN on resumption, it must match the earlier one
+	var err error
+	if psk != nil && psk.IsResumption && (len(offered) > 0) {
+		err = fmt.Errorf("ALPN for PSK not provided")
+	}
+	return "", err
+}

--- a/negotiation_test.go
+++ b/negotiation_test.go
@@ -1,0 +1,194 @@
+package mint
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestVersionNegotiation(t *testing.T) {
+	// Test successful negotiation
+	ok, negotiated := versionNegotiation([]uint16{0x0301, 0x7f12}, []uint16{0x0302, 0x7f12})
+	assertEquals(t, ok, true)
+	assertEquals(t, negotiated, uint16(0x7f12))
+
+	// Test failed negotiation
+	ok, negotiated = versionNegotiation([]uint16{0x0300}, []uint16{0x0400})
+	assertEquals(t, ok, false)
+}
+
+func TestDHNegotiation(t *testing.T) {
+	keyShares := []keyShareEntry{
+		{Group: P256, KeyExchange: random(keyExchangeSizeFromNamedGroup(P256))},
+		{Group: X25519, KeyExchange: random(keyExchangeSizeFromNamedGroup(X25519))},
+	}
+	badKeyShares := []keyShareEntry{
+		{Group: P256, KeyExchange: random(keyExchangeSizeFromNamedGroup(P256) - 2)},
+		{Group: X25519, KeyExchange: random(keyExchangeSizeFromNamedGroup(X25519))},
+	}
+
+	// Test successful negotiation
+	ok, group, pub, secret := dhNegotiation(keyShares, []NamedGroup{X25519})
+	assertEquals(t, ok, true)
+	assertEquals(t, group, X25519)
+	assertNotNil(t, pub, "Nil public key")
+	assertNotNil(t, secret, "Nil DH secret")
+
+	// Test continuation on newKeyShare failure
+	// XXX: Would be better to test success, but more difficult.  This will at
+	// least cover the branch
+	originalPRNG := prng
+	prng = bytes.NewBuffer(nil)
+	ok, group, pub, secret = dhNegotiation(badKeyShares, []NamedGroup{P256, X25519})
+	assertEquals(t, ok, false)
+	prng = originalPRNG
+
+	// Test continuation on keyAgreement failure
+	ok, group, pub, secret = dhNegotiation(badKeyShares, []NamedGroup{P256, X25519})
+	assertEquals(t, ok, true)
+	assertEquals(t, group, X25519)
+	assertNotNil(t, pub, "Nil public key")
+	assertNotNil(t, secret, "Nil DH secret")
+
+	// Test failure
+	ok, _, _, _ = dhNegotiation(keyShares, []NamedGroup{P521})
+	assertEquals(t, ok, false)
+}
+
+func TestPSKNegotiation(t *testing.T) {
+	chTrunc, _ := hex.DecodeString("0001020304050607")
+	binderValue, _ := hex.DecodeString("9c4bfad67420fbc3f03809744929f9f3d21030fd15e886881bbe21b7ca28ee16")
+
+	identities := []pskIdentity{
+		{Identity: []byte{0, 1, 2, 3}},
+		{Identity: []byte{4, 5, 6, 7}},
+	}
+	binders := []pskBinderEntry{
+		{Binder: binderValue},
+		{Binder: binderValue},
+	}
+	badBinders := []pskBinderEntry{
+		{Binder: []byte{}},
+		{Binder: []byte{}},
+	}
+	psks := map[string]PreSharedKey{
+		"example.com": {
+			CipherSuite: TLS_AES_128_GCM_SHA256,
+			Identity:    []byte{4, 5, 6, 7},
+			Key:         []byte{0, 1, 2, 3},
+		},
+	}
+
+	// Test successful negotiation
+	ok, selected, psk, ctx, err := pskNegotiation(identities, binders, chTrunc, psks)
+	assertEquals(t, ok, true)
+	assertEquals(t, selected, 1)
+	assertNotNil(t, psk, "PSK not set")
+	assertNotNil(t, ctx.pskSecret, "PSK secret not set")
+	assertNotError(t, err, "Valid PSK negotiation failed")
+
+	// Test negotiation failure on binder value failure
+	ok, _, _, _, err = pskNegotiation(identities, badBinders, chTrunc, psks)
+	assertEquals(t, ok, false)
+	assertError(t, err, "Failed to error on binder failure")
+
+	// Test negotiation failure on no PSK overlap
+	ok, _, _, _, err = pskNegotiation(identities, binders, chTrunc, map[string]PreSharedKey{})
+	assertEquals(t, ok, false)
+	assertNotError(t, err, "Errored on PSK negotiation failure")
+}
+
+func TestPSKModeNegotiation(t *testing.T) {
+	// Test that everything that's allowed gets used
+	usingDH, usingPSK := pskModeNegotiation(true, true, []PSKKeyExchangeMode{PSKModeKE, PSKModeDHEKE})
+	assert(t, usingDH, "Unnecessarily disabled DH")
+	assert(t, usingPSK, "Unnecessarily disabled PSK")
+
+	// Test that DH is disabled when not allowed with the PSK
+	usingDH, usingPSK = pskModeNegotiation(true, true, []PSKKeyExchangeMode{PSKModeKE})
+	assert(t, !usingDH, "Should not have enabled DH")
+	assert(t, usingPSK, "Unnecessarily disabled PSK")
+
+	// Test that the PSK is disabled when DH is required but not possible
+	usingDH, usingPSK = pskModeNegotiation(false, true, []PSKKeyExchangeMode{PSKModeDHEKE})
+	assert(t, !usingDH, "Should not have enabled DH")
+	assert(t, !usingPSK, "Should not have enabled PSK")
+}
+
+func TestCertificateSelection(t *testing.T) {
+	rsa := []SignatureScheme{RSA_PKCS1_SHA256}
+	eddsa := []SignatureScheme{Ed25519}
+
+	// Test success
+	cert, scheme, err := certificateSelection("example.com", rsa, certificates)
+	assertNotError(t, err, "Failed to find certificate in a valid set")
+	assertNotNil(t, cert, "Failed to set certificate")
+	assertEquals(t, scheme, RSA_PKCS1_SHA256)
+
+	// Test failure on no certs matching host name
+	cert, scheme, err = certificateSelection("not-example.com", rsa, certificates)
+	assertError(t, err, "Found a certificate for an incorrect host name")
+
+	// Test failure on no certs matching signature scheme
+	cert, scheme, err = certificateSelection("example.com", eddsa, certificates)
+	assertError(t, err, "Found a certificate for an incorrect signature scheme")
+}
+
+func TestEarlyDataNegotiation(t *testing.T) {
+	useEarlyData := earlyDataNegotiation(true, true, true)
+	assert(t, useEarlyData, "Did not use early data when allowed")
+
+	useEarlyData = earlyDataNegotiation(false, true, true)
+	assert(t, !useEarlyData, "Allowed early data when not using PSK")
+
+	useEarlyData = earlyDataNegotiation(true, false, true)
+	assert(t, !useEarlyData, "Allowed early data when not signaled")
+
+	useEarlyData = earlyDataNegotiation(true, true, false)
+	assert(t, !useEarlyData, "Allowed early data when not allowed")
+}
+
+func TestCipherSuiteNegotiation(t *testing.T) {
+	offered := []CipherSuite{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256}
+	supported := []CipherSuite{TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256}
+	psk := &PreSharedKey{CipherSuite: TLS_CHACHA20_POLY1305_SHA256}
+
+	// Test success with PSK-specified suite
+	suite, err := cipherSuiteNegotiation(psk, offered, supported)
+	assertNotError(t, err, "CipherSuite negotiation with PSK failed")
+	assertEquals(t, suite, psk.CipherSuite)
+
+	// Test success with no PSK
+	suite, err = cipherSuiteNegotiation(nil, offered, supported)
+	assertNotError(t, err, "CipherSuite negotiation without PSK failed")
+	assertEquals(t, suite, TLS_AES_256_GCM_SHA384)
+
+	// Test failure
+	_, err = cipherSuiteNegotiation(nil, []CipherSuite{TLS_AES_128_GCM_SHA256}, supported)
+	assertError(t, err, "CipherSuite negotiation succeeded with no overlap")
+}
+
+func TestALPNNegotiation(t *testing.T) {
+	offered := []string{"http/1.1", "h2"}
+	supported := []string{"h2", "spdy/1.1"}
+	psk := &PreSharedKey{NextProto: "h2", IsResumption: true}
+
+	// Test success with PSK-specified protocol
+	proto, err := alpnNegotiation(psk, offered, supported)
+	assertNotError(t, err, "ALPN negotiation with PSK failed")
+	assertEquals(t, proto, psk.NextProto)
+
+	// Test success with no PSK
+	proto, err = alpnNegotiation(nil, offered, supported)
+	assertNotError(t, err, "ALPN negotiation without PSK failed")
+	assertEquals(t, proto, "h2")
+
+	// Test failure on resumption and mismatch
+	proto, err = alpnNegotiation(psk, []string{"http/1.1"}, []string{})
+	assertError(t, err, "Resumption allowed without offer having previous ALPN")
+
+	// Test failure without resumption
+	proto, err = alpnNegotiation(nil, []string{"http/1.1"}, []string{})
+	assertNotError(t, err, "ALPN mismatch caused an error")
+	assertEquals(t, proto, "")
+}


### PR DESCRIPTION
This PR pulls most of the server handshake out into a set of negotiation functions that can be individually unit-tested, for more readability and better test coverage.

This PR also makes PSK support more correct by adding support for the PskKeyExchangeModes extension.