### PR TITLE
Store ALPN in the session cache

### DIFF
--- a/state-machine.go
+++ b/state-machine.go
@@ -1854,6 +1854,7 @@ func (state *StateConnected) NewSessionTicket(length int, lifetime, earlyDataLif
 		IsResumption: true,
 		Identity:     tkt.Ticket,
 		Key:          state.resumptionSecret,
+		NextProto:    state.Params.NextProto,
 	}
 
 	tktm, err := HandshakeMessageFromBody(tkt)
@@ -1919,6 +1920,7 @@ func (state StateConnected) Next(hm *HandshakeMessage) (HandshakeState, []Handsh
 			IsResumption: true,
 			Identity:     body.Ticket,
 			Key:          state.resumptionSecret,
+			NextProto:    state.Params.NextProto,
 		}
 
 		toSend := []HandshakeInstruction{StorePSK{psk}}


### PR DESCRIPTION
We have enforcement of ALPN matching for resumption / PSK, but weren't populating the field in the `PreSharedKey` object.