### PR TITLE
Make the SendSessionTicket configuration parameter actually work.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -677,7 +677,7 @@ func (c *Conn) Handshake() Alert {
 	c.state = state.(StateConnected)
 
 	// Send NewSessionTicket if acting as server
-	if !c.isClient {
+	if !c.isClient && c.config.SendSessionTickets {
 		actions, alert := c.state.NewSessionTicket(
 			c.config.TicketLen,
 			c.config.TicketLifetime,


### PR DESCRIPTION
Note that this is an API change in that the default in the
configuration is for this value to be false. Thus, people who
were previously relying on the default (broken) behavior for
this configuration flag will not get session tickets. Alternately,
we can remove this config flag and replace it with one that
goes the other way.