### PR TITLE
implement a CookieHandler to manually set and validate cookies

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -39,11 +39,11 @@ type PreSharedKeyCache interface {
 type PSKMapCache map[string]PreSharedKey
 
 // A CookieHandler does two things:
-// - generates cookies that are sent to the client in the HelloRetryRequest
-// - validates cookies sent by the client in a ClientHello
+// - generates a byte string that is sent as a part of a cookie to the client in the HelloRetryRequest
+// - validates this byte string echoed by the client in the ClientHello
 type CookieHandler interface {
-	Generate(*Conn) (*CookieExtension, error)
-	Validate(*Conn, *CookieExtension) bool
+	Generate(*Conn) ([]byte, error)
+	Validate(*Conn, []byte) bool
 }
 
 func (cache PSKMapCache) Get(key string) (psk PreSharedKey, ok bool) {

--- a/conn.go
+++ b/conn.go
@@ -38,6 +38,14 @@ type PreSharedKeyCache interface {
 
 type PSKMapCache map[string]PreSharedKey
 
+// A CookieHandler does two things:
+// - generates cookies that are sent to the client in the HelloRetryRequest
+// - validates cookies sent by the client in a ClientHello
+type CookieHandler interface {
+	Generate(*Conn) (*CookieExtension, error)
+	Validate(*Conn, *CookieExtension) bool
+}
+
 func (cache PSKMapCache) Get(key string) (psk PreSharedKey, ok bool) {
 	psk, ok = cache[key]
 	return
@@ -64,8 +72,12 @@ type Config struct {
 	TicketLen          int
 	EarlyDataLifetime  uint32
 	AllowEarlyData     bool
-	RequireCookie      bool
-	RequireClientAuth  bool
+	// Require the client to echo a cookie.
+	RequireCookie bool
+	// If cookies are required and no CookieHandler is set, a default cookie handler is used.
+	// The default cookie handler uses 32 random bytes as a cookie.
+	CookieHandler     CookieHandler
+	RequireClientAuth bool
 
 	// Shared fields
 	Certificates     []*Certificate
@@ -599,6 +611,7 @@ func (c *Conn) HandshakeSetup() Alert {
 		PSKModes:          c.config.PSKModes,
 		AllowEarlyData:    c.config.AllowEarlyData,
 		RequireCookie:     c.config.RequireCookie,
+		CookieHandler:     c.config.CookieHandler,
 		RequireClientAuth: c.config.RequireClientAuth,
 		NextProtos:        c.config.NextProtos,
 		Certificates:      c.config.Certificates,
@@ -608,6 +621,10 @@ func (c *Conn) HandshakeSetup() Alert {
 		ServerName: c.config.ServerName,
 		NextProtos: c.config.NextProtos,
 		EarlyData:  c.EarlyData,
+	}
+
+	if caps.RequireCookie && caps.CookieHandler == nil {
+		caps.CookieHandler = &defaultCookieHandler{}
 	}
 
 	if c.isClient {
@@ -625,7 +642,7 @@ func (c *Conn) HandshakeSetup() Alert {
 			}
 		}
 	} else {
-		state = ServerStateStart{Caps: caps}
+		state = ServerStateStart{Caps: caps, conn: c}
 	}
 
 	c.hState = state

--- a/extensions.go
+++ b/extensions.go
@@ -573,15 +573,14 @@ type defaultCookieHandler struct {
 var _ CookieHandler = &defaultCookieHandler{}
 
 // NewRandomCookie generates a cookie with DefaultCookieLength bytes of random data
-func (h *defaultCookieHandler) Generate(*Conn) (*CookieExtension, error) {
+func (h *defaultCookieHandler) Generate(*Conn) ([]byte, error) {
 	h.data = make([]byte, defaultCookieLength)
 	if _, err := prng.Read(h.data); err != nil {
 		return nil, err
 	}
-	cookie := &CookieExtension{Cookie: h.data}
-	return cookie, nil
+	return h.data, nil
 }
 
-func (h *defaultCookieHandler) Validate(_ *Conn, c *CookieExtension) bool {
-	return bytes.Equal(h.data, c.Cookie)
+func (h *defaultCookieHandler) Validate(_ *Conn, data []byte) bool {
+	return bytes.Equal(h.data, data)
 }

--- a/server-state-machine.go
+++ b/server-state-machine.go
@@ -59,8 +59,9 @@ import (
 
 type ServerStateStart struct {
 	Caps Capabilities
+	conn *Conn
 
-	cookie            []byte
+	cookieSent        bool
 	firstClientHello  *HandshakeMessage
 	helloRetryRequest *HandshakeMessage
 }
@@ -128,8 +129,8 @@ func (state ServerStateStart) Next(hm *HandshakeMessage) (HandshakeState, []Hand
 		return nil, nil, AlertProtocolVersion
 	}
 
-	if state.Caps.RequireCookie && state.cookie != nil && !bytes.Equal(state.cookie, clientCookie.Cookie) {
-		logf(logTypeHandshake, "[ServerStateStart] Cookie mismatch [%x] != [%x]", clientCookie.Cookie, state.cookie)
+	if state.Caps.RequireCookie && state.cookieSent && !state.Caps.CookieHandler.Validate(state.conn, clientCookie) {
+		logf(logTypeHandshake, "[ServerStateStart] Cookie mismatch")
 		return nil, nil, AlertAccessDenied
 	}
 
@@ -178,8 +179,8 @@ func (state ServerStateStart) Next(hm *HandshakeMessage) (HandshakeState, []Hand
 	// NB: Need to do this here because it's after ciphersuite selection, which
 	// has to be after PSK selection.
 	// XXX: Doing this statefully for now, could be stateless
-	if state.Caps.RequireCookie && state.cookie == nil {
-		cookie, err := NewCookie()
+	if state.Caps.RequireCookie && !state.cookieSent {
+		cookie, err := state.Caps.CookieHandler.Generate(state.conn)
 		if err != nil {
 			logf(logTypeHandshake, "[ServerStateStart] Error generating cookie [%v]", err)
 			return nil, nil, AlertInternalError
@@ -218,7 +219,8 @@ func (state ServerStateStart) Next(hm *HandshakeMessage) (HandshakeState, []Hand
 
 		nextState := ServerStateStart{
 			Caps:              state.Caps,
-			cookie:            cookie.Cookie,
+			conn:              state.conn,
+			cookieSent:        true,
 			firstClientHello:  firstClientHello,
 			helloRetryRequest: helloRetryRequest,
 		}

--- a/state-machine.go
+++ b/state-machine.go
@@ -60,6 +60,7 @@ type Capabilities struct {
 	NextProtos        []string
 	AllowEarlyData    bool
 	RequireCookie     bool
+	CookieHandler     CookieHandler
 	RequireClientAuth bool
 }
 

--- a/state-machine_test.go
+++ b/state-machine_test.go
@@ -70,6 +70,7 @@ var (
 				PSKs:             &PSKMapCache{},
 				Certificates:     certificates,
 				RequireCookie:    true,
+				CookieHandler:    &defaultCookieHandler{},
 			},
 			clientStateSequence: []HandshakeState{
 				ClientStateStart{},


### PR DESCRIPTION
By setting a `CookieHandler`, the user can provide an opaque byte-slice that is used as a cookie in the HRR, and validate the cookie when the client echos it in the CH. Mint passes a pointer to the `Conn` to the methods that generate and validate the cookie. It's the responsibility of the cookie handler implementation to decide if a cookie should be sent for this specific connection..

If `Config.RequireCookie` is set to `true`, but no `Config.CookieHandler` is defined, a default cookie handler is used (the one that was already implemented). The default handler uses 32 random bytes as a cookie.

I'm not sure where the appropriate place would be to test a failed cookie validation. I guess *state-machine_test.go* would be the right place, but the tests there only cover successful handshakes.

@ekr: It would be great if you could review this PR as well.