### PR TITLE
implement a string representation of the CipherSuite

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,5 +1,10 @@
 package mint
 
+import (
+	"fmt"
+	"strconv"
+)
+
 var (
 	supportedVersion uint16 = 0x7f15 // draft-21
 
@@ -50,6 +55,25 @@ const (
 	TLS_AES_128_CCM_SHA256       CipherSuite = 0x1304
 	TLS_AES_256_CCM_8_SHA256     CipherSuite = 0x1305
 )
+
+func (c CipherSuite) String() string {
+	switch c {
+	case CIPHER_SUITE_UNKNOWN:
+		return "unknown"
+	case TLS_AES_128_GCM_SHA256:
+		return "TLS_AES_128_GCM_SHA256"
+	case TLS_AES_256_GCM_SHA384:
+		return "TLS_AES_256_GCM_SHA384"
+	case TLS_CHACHA20_POLY1305_SHA256:
+		return "TLS_CHACHA20_POLY1305_SHA256"
+	case TLS_AES_128_CCM_SHA256:
+		return "TLS_AES_128_CCM_SHA256"
+	case TLS_AES_256_CCM_8_SHA256:
+		return "TLS_AES_256_CCM_8_SHA256"
+	}
+	// cannot use %x here, since it calls String(), leading to infinite recursion
+	return fmt.Sprintf("invalid CipherSuite value: 0x%s", strconv.FormatUint(uint64(c), 16))
+}
 
 // enum {...} SignatureScheme
 type SignatureScheme uint16


### PR DESCRIPTION
I'd like to be able to log the cipher suite negotiated in the handshake. Having a string representation of the `CipherSuite` would be very handy for that.