### PR TITLE
do not automatically advance state in non-blocking mode

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -354,6 +355,9 @@ func (c *Conn) consumeRecord() error {
 // Read application data up to the size of buffer.  Handshake and alert records
 // are consumed by the Conn object directly.
 func (c *Conn) Read(buffer []byte) (int, error) {
+	if _, connected := c.hState.(StateConnected); !connected && c.config.NonBlocking {
+		return 0, errors.New("Read called before the handshake completed")
+	}
 	logf(logTypeHandshake, "conn.Read with buffer = %d", len(buffer))
 	if alert := c.Handshake(); alert != AlertNoAlert {
 		return 0, alert

--- a/conn_test.go
+++ b/conn_test.go
@@ -269,12 +269,14 @@ var (
 )
 
 func assertKeySetEquals(t *testing.T, k1, k2 keySet) {
+	t.Helper()
 	// Assume cipher is the same
 	assertByteEquals(t, k1.iv, k2.iv)
 	assertByteEquals(t, k1.key, k2.key)
 }
 
 func computeExporter(t *testing.T, c *Conn, label string, context []byte, length int) []byte {
+	t.Helper()
 	res, err := c.ComputeExporter(label, context, length)
 	assertNotError(t, err, "Could not compute exporter")
 	return res
@@ -581,10 +583,10 @@ func TestKeyUpdate(t *testing.T) {
 	}(t)
 
 	alert := client.Handshake()
+	assertEquals(t, alert, AlertNoAlert)
 
 	// Read NST.
 	client.Read(oneBuf)
-	assertEquals(t, alert, AlertNoAlert)
 	<-s2c
 
 	clientState0 := client.state
@@ -647,7 +649,7 @@ func TestNonblockingHandshakeAndDataFlow(t *testing.T) {
 
 	// Send ClientHello
 	clientAlert = client.Handshake()
-	assertEquals(t, clientAlert, AlertWouldBlock)
+	assertEquals(t, clientAlert, AlertNoAlert)
 	serverAlert = server.Handshake()
 	assertEquals(t, serverAlert, AlertWouldBlock)
 
@@ -655,8 +657,13 @@ func TestNonblockingHandshakeAndDataFlow(t *testing.T) {
 	cbConn.Flush()
 
 	// Process ClientHello, send server first flight.
-	serverAlert = server.Handshake()
-	assertEquals(t, serverAlert, AlertWouldBlock)
+	for {
+		serverAlert = server.Handshake()
+		if serverAlert == AlertWouldBlock {
+			break
+		}
+		assertEquals(t, serverAlert, AlertNoAlert)
+	}
 
 	clientAlert = client.Handshake()
 	assertEquals(t, clientAlert, AlertWouldBlock)
@@ -671,8 +678,13 @@ func TestNonblockingHandshakeAndDataFlow(t *testing.T) {
 
 	// Release client's second flight.
 	cbConn.Flush()
-	serverAlert = server.Handshake()
-	assertEquals(t, serverAlert, AlertNoAlert)
+	for {
+		serverAlert = server.Handshake()
+		if serverAlert == AlertWouldBlock {
+			break
+		}
+		assertEquals(t, serverAlert, AlertNoAlert)
+	}
 
 	assertDeepEquals(t, client.state.Params, server.state.Params)
 	assertCipherSuiteParamsEquals(t, client.state.cryptoParams, server.state.cryptoParams)

--- a/conn_test.go
+++ b/conn_test.go
@@ -391,6 +391,12 @@ func TestPSKFlows(t *testing.T) {
 	}
 }
 
+func TestNonBlockingReadBeforeConnected(t *testing.T) {
+	conn := Client(&bufferedConn{}, &Config{NonBlocking: true})
+	_, err := conn.Read(make([]byte, 10))
+	assertEquals(t, err.Error(), "Read called before the handshake completed")
+}
+
 func TestResumption(t *testing.T) {
 	// Phase 1: Verify that the session ticket gets sent and stored
 	clientConfig := resumptionConfig.Clone()

--- a/handshake-layer.go
+++ b/handshake-layer.go
@@ -201,6 +201,7 @@ func (h *HandshakeLayer) ReadMessage() (*HandshakeMessage, error) {
 
 	hm.body = make([]byte, len(body))
 	copy(hm.body, body)
+	logf(logTypeHandshake, "Read message with type: %v", hm.msgType)
 
 	return hm, nil
 }

--- a/tls.go
+++ b/tls.go
@@ -51,11 +51,14 @@ func (l *Listener) Accept() (c net.Conn, err error) {
 // Listener and wraps each connection with Server.
 // The configuration config must be non-nil and must include
 // at least one certificate or else set GetCertificate.
-func NewListener(inner net.Listener, config *Config) net.Listener {
+func NewListener(inner net.Listener, config *Config) (net.Listener, error) {
+	if config != nil && config.NonBlocking {
+		return nil, errors.New("listening not possible in non-blocking mode")
+	}
 	l := new(Listener)
 	l.Listener = inner
 	l.config = config
-	return l
+	return l, nil
 }
 
 // Listen creates a TLS listener accepting connections on the
@@ -70,7 +73,7 @@ func Listen(network, laddr string, config *Config) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewListener(l, config), nil
+	return NewListener(l, config)
 }
 
 type TimeoutError struct{}
@@ -87,6 +90,9 @@ func (TimeoutError) Temporary() bool { return true }
 // DialWithDialer interprets a nil configuration as equivalent to the zero
 // configuration; see the documentation of Config for the defaults.
 func DialWithDialer(dialer *net.Dialer, network, addr string, config *Config) (*Conn, error) {
+	if config != nil && config.NonBlocking {
+		return nil, errors.New("dialing not possible in non-blocking mode")
+	}
 	// We want the Timeout and Deadline values from dialer to cover the
 	// whole process: TCP connection and TLS handshake. This means that we
 	// also need to start our own timers now.

--- a/tls_test.go
+++ b/tls_test.go
@@ -55,6 +55,25 @@ func TestDialTimeout(t *testing.T) {
 	}
 }
 
+func TestDialNonBlocking(t *testing.T) {
+	config := &Config{NonBlocking: true}
+	_, err := Dial("tcp", "localhost:1234", config)
+	assertEquals(t, err.Error(), "dialing not possible in non-blocking mode")
+	_, err = DialWithDialer(&net.Dialer{}, "tcp", "localhost:1234", config)
+	assertEquals(t, err.Error(), "dialing not possible in non-blocking mode")
+}
+
+func TestListenNonBlocking(t *testing.T) {
+	config := &Config{
+		NonBlocking:  true,
+		Certificates: certificates,
+	}
+	_, err := Listen("tcp", "localhost:1234", config)
+	assertEquals(t, err.Error(), "listening not possible in non-blocking mode")
+	_, err = NewListener(newLocalListener(t), config)
+	assertEquals(t, err.Error(), "listening not possible in non-blocking mode")
+}
+
 // tests that Conn.Read returns (non-zero, io.EOF) instead of
 // (non-zero, nil) when a Close (alertCloseNotify) is sitting right
 // behind the application data in the buffer.


### PR DESCRIPTION
Fixes #143. Should be merged after #141.

In non-blocking mode, `Handshake()` now returns after every state transition with `AlertNoAlert`. If `Handshake` is called, but would block while reading a new record, it returns `AlertWouldBlock`.
The state of the handshake is now returned by `Conn.GetHsState()`.

@ekr, @bifurcation: What do you think about this?

