### PR TITLE
Add explicit marshal/unmarshal to the TLS syntax module

### DIFF
--- a/syntax/decode.go
+++ b/syntax/decode.go
@@ -79,11 +79,6 @@ var (
 )
 
 func newTypeDecoder(t reflect.Type) decoderFunc {
-	// XXX Unmarshalers are only supported by value.  That is, if Foo
-	// implements Unmarshaler, then:
-	//
-	// type A struct { f Foo }	 <-- OK
-	// type B struct { f *Foo }  <-- Not OK
 	if t.Kind() != reflect.Ptr && reflect.PtrTo(t).Implements(unmarshalerType) {
 		return unmarshalerDecoder
 	}
@@ -107,7 +102,7 @@ func newTypeDecoder(t reflect.Type) decoderFunc {
 func unmarshalerDecoder(d *decodeState, v reflect.Value, opts decOpts) int {
 	um, ok := v.Interface().(Unmarshaler)
 	if !ok {
-		panic(fmt.Errorf("Non-Unarshaler passed to unmarshalerEncoder"))
+		panic(fmt.Errorf("Non-Unmarshaler passed to unmarshalerEncoder"))
 	}
 
 	read, err := um.UnmarshalTLS(d.Bytes())

--- a/syntax/decode_test.go
+++ b/syntax/decode_test.go
@@ -153,18 +153,31 @@ func TestDecodeStruct(t *testing.T) {
 }
 
 func TestDecodeUnmarshaler(t *testing.T) {
+	crypticStringUnmarshalCalls = 0
 	var ym CrypticString
 	read, err := Unmarshal(zm, &ym)
+
 	if err != nil || !reflect.DeepEqual(ym, xm) || read != len(zm) {
-		t.Fatalf("struct decode failed [%v] [%v]", err, ym)
+		t.Fatalf("Unmarshaler decode failed [%v] [%v]", err, ym)
 	}
 
-	var ym2 struct {
-		Content CrypticString
+	if crypticStringUnmarshalCalls != 1 {
+		t.Fatalf("CrypticString.UnmarshalTLS() was not called exactly once [%v]", crypticStringUnmarshalCalls)
 	}
-	read, err = Unmarshal(zm, &ym2)
-	if err != nil || !reflect.DeepEqual(ym2.Content, xm) || read != len(zm) {
-		t.Fatalf("struct decode failed [%v] [%v]", err, ym2)
+
+	crypticStringUnmarshalCalls = 0
+	var ysm struct {
+		A CrypticString
+		B uint16
+		C CrypticString
+	}
+	read, err = Unmarshal(zsm, &ysm)
+	if err != nil || !reflect.DeepEqual(ysm, xsm) || read != len(zsm) {
+		t.Fatalf("Struct-embedded unmarshaler decode failed [%v] [%v]", err, ysm)
+	}
+
+	if crypticStringUnmarshalCalls != 2 {
+		t.Fatalf("CrypticString.UnmarshalTLS() was not called exactly twice [%v]", crypticStringUnmarshalCalls)
 	}
 }
 

--- a/syntax/decode_test.go
+++ b/syntax/decode_test.go
@@ -152,6 +152,22 @@ func TestDecodeStruct(t *testing.T) {
 	}
 }
 
+func TestDecodeUnmarshaler(t *testing.T) {
+	var ym CrypticString
+	read, err := Unmarshal(zm, &ym)
+	if err != nil || !reflect.DeepEqual(ym, xm) || read != len(zm) {
+		t.Fatalf("struct decode failed [%v] [%v]", err, ym)
+	}
+
+	var ym2 struct {
+		Content CrypticString
+	}
+	read, err = Unmarshal(zm, &ym2)
+	if err != nil || !reflect.DeepEqual(ym2.Content, xm) || read != len(zm) {
+		t.Fatalf("struct decode failed [%v] [%v]", err, ym2)
+	}
+}
+
 func TestIgnoreExtraData(t *testing.T) {
 	zsExtra := append(zs1, 0)
 	var ys1 struct {

--- a/syntax/encode.go
+++ b/syntax/encode.go
@@ -77,10 +77,6 @@ func newTypeEncoder(t reflect.Type) encoderFunc {
 		return marshalerEncoder
 	}
 
-	// XXX: Not doing the condAddrEncoder stuff that encoding/json
-	// does. I think that's only necessary because they want to
-	// reflect nil pointers as "null", which we don't want here.
-
 	switch t.Kind() {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return uintEncoder

--- a/syntax/encode.go
+++ b/syntax/encode.go
@@ -16,6 +16,12 @@ func Marshal(v interface{}) ([]byte, error) {
 	return e.Bytes(), nil
 }
 
+// Marshaler is the interface implemented by types that
+// have a defined TLS encoding.
+type Marshaler interface {
+	MarshalTLS() ([]byte, error)
+}
+
 // These are the options that can be specified in the struct tag.  Right now,
 // all of them apply to variable-length vectors and nothing else
 type encOpts struct {
@@ -62,8 +68,18 @@ func typeEncoder(t reflect.Type) encoderFunc {
 	return newTypeEncoder(t)
 }
 
+var (
+	marshalerType = reflect.TypeOf(new(Marshaler)).Elem()
+)
+
 func newTypeEncoder(t reflect.Type) encoderFunc {
-	// Note: Does not support Marshaler, so don't need the allowAddr argument
+	if t.Implements(marshalerType) {
+		return marshalerEncoder
+	}
+
+	// XXX: Not doing the condAddrEncoder stuff that encoding/json
+	// does. I think that's only necessary because they want to
+	// reflect nil pointers as "null", which we don't want here.
 
 	switch t.Kind() {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
@@ -80,6 +96,28 @@ func newTypeEncoder(t reflect.Type) encoderFunc {
 }
 
 ///// Specific encoders below
+
+func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		panic(fmt.Errorf("Cannot encode nil pointer"))
+	}
+
+	m, ok := v.Interface().(Marshaler)
+	if !ok {
+		panic(fmt.Errorf("Non-Marshaler passed to marshalerEncoder"))
+	}
+
+	b, err := m.MarshalTLS()
+	if err == nil {
+		_, err = e.Write(b)
+	}
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+//////////
 
 func uintEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	u := v.Uint()

--- a/syntax/pointer-fail_test.go
+++ b/syntax/pointer-fail_test.go
@@ -1,0 +1,55 @@
+package syntax
+
+import (
+	"testing"
+)
+
+// TODO(rlb@ipv.sx): This module does not currently support
+// marshal/unmarshal of structs with embedded pointer types.  (By
+// contrast, encoding/json will dereference on marshal / allocate on
+// unmarshal.)  These tests just demonstrate that failure.  They can
+// be removed once pointer support is added.
+
+type InnerStruct struct {
+	A uint8
+}
+
+type WithValue struct {
+	Inner InnerStruct
+}
+
+type WithPointer struct {
+	Inner *InnerStruct
+}
+
+func TestPtrEncodeFailure(t *testing.T) {
+	inner := InnerStruct{0xFF}
+	withValue := WithValue{inner}
+	withPointer := WithPointer{&inner}
+
+	_, err := Marshal(withValue)
+	if err != nil {
+		t.Fatalf("Marshal with value should have succeeded: [%v]", err)
+	}
+
+	_, err = Marshal(withPointer)
+	if err == nil {
+		t.Fatalf("Marshal with pointer should have failed: [%v]", err)
+	}
+}
+
+func TestPtrDecodeFailure(t *testing.T) {
+	data := []byte{0xFF}
+	var withValue WithValue
+	var withPointer WithPointer
+
+	_, err := Unmarshal(data, &withValue)
+	if err != nil {
+		t.Fatalf("Unmarshal with value should have succeeded: [%v]", err)
+	}
+
+	_, err = Unmarshal(data, &withPointer)
+	if err == nil {
+		t.Fatalf("Unmarshal with pointer should have failed: [%v]", err)
+	}
+}


### PR DESCRIPTION
I think this will offer a path to implementing the `select` syntax, e.g., to make encode/decode of `HandshakeMessage` more elegant.