### PR TITLE
privatize handshake states

### DIFF
--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -50,7 +50,7 @@ import (
 //  WAIT_FINISHED			RekeyIn; [Send(EOED);] RekeyOut; [SendCert; SendCV;] SendFin; RekeyOut;
 //  CONNECTED					StoreTicket || (RekeyIn; [RekeyOut])
 
-type ClientStateStart struct {
+type clientStateStart struct {
 	Config *Config
 	Opts   ConnectionOptions
 	Params ConnectionParameters
@@ -61,13 +61,13 @@ type ClientStateStart struct {
 	hsCtx             HandshakeContext
 }
 
-var _ HandshakeState = &ClientStateStart{}
+var _ HandshakeState = &clientStateStart{}
 
-func (state ClientStateStart) State() State {
+func (state clientStateStart) State() State {
 	return StateClientStart
 }
 
-func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateStart) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	// key_shares
 	offeredDH := map[NamedGroup][]byte{}
 	ks := KeyShareExtension{
@@ -268,7 +268,7 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 
 	logf(logTypeHandshake, "[ClientStateStart] -> [ClientStateWaitSH]")
 	state.hsCtx.SetVersion(tls12Version) // Everything after this should be 1.2.
-	nextState := ClientStateWaitSH{
+	nextState := clientStateWaitSH{
 		Config:     state.Config,
 		Opts:       state.Opts,
 		Params:     state.Params,
@@ -298,7 +298,7 @@ func (state ClientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	return nextState, toSend, AlertNoAlert
 }
 
-type ClientStateWaitSH struct {
+type clientStateWaitSH struct {
 	Config     *Config
 	Opts       ConnectionOptions
 	Params     ConnectionParameters
@@ -315,13 +315,13 @@ type ClientStateWaitSH struct {
 	clientHello       *HandshakeMessage
 }
 
-var _ HandshakeState = &ClientStateWaitSH{}
+var _ HandshakeState = &clientStateWaitSH{}
 
-func (state ClientStateWaitSH) State() State {
+func (state clientStateWaitSH) State() State {
 	return StateClientWaitSH
 }
 
-func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -413,7 +413,7 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 		}
 
 		logf(logTypeHandshake, "[ClientStateWaitSH] -> [ClientStateStart]")
-		return ClientStateStart{
+		return clientStateStart{
 			Config:            state.Config,
 			Opts:              state.Opts,
 			hsCtx:             state.hsCtx,
@@ -517,7 +517,7 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 	serverHandshakeKeys := makeTrafficKeys(params, serverHandshakeTrafficSecret)
 
 	logf(logTypeHandshake, "[ClientStateWaitSH] -> [ClientStateWaitEE]")
-	nextState := ClientStateWaitEE{
+	nextState := clientStateWaitEE{
 		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
@@ -533,7 +533,7 @@ func (state ClientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 	return nextState, toSend, AlertNoAlert
 }
 
-type ClientStateWaitEE struct {
+type clientStateWaitEE struct {
 	Config                       *Config
 	Params                       ConnectionParameters
 	hsCtx                        HandshakeContext
@@ -544,13 +544,13 @@ type ClientStateWaitEE struct {
 	serverHandshakeTrafficSecret []byte
 }
 
-var _ HandshakeState = &ClientStateWaitEE{}
+var _ HandshakeState = &clientStateWaitEE{}
 
-func (state ClientStateWaitEE) State() State {
+func (state clientStateWaitEE) State() State {
 	return StateClientWaitEE
 }
 
-func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -598,7 +598,7 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 
 	if state.Params.UsingPSK {
 		logf(logTypeHandshake, "[ClientStateWaitEE] -> [ClientStateWaitFinished]")
-		nextState := ClientStateWaitFinished{
+		nextState := clientStateWaitFinished{
 			Params:                       state.Params,
 			hsCtx:                        state.hsCtx,
 			cryptoParams:                 state.cryptoParams,
@@ -612,7 +612,7 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 	}
 
 	logf(logTypeHandshake, "[ClientStateWaitEE] -> [ClientStateWaitCertCR]")
-	nextState := ClientStateWaitCertCR{
+	nextState := clientStateWaitCertCR{
 		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
@@ -625,7 +625,7 @@ func (state ClientStateWaitEE) Next(hr handshakeMessageReader) (HandshakeState, 
 	return nextState, nil, AlertNoAlert
 }
 
-type ClientStateWaitCertCR struct {
+type clientStateWaitCertCR struct {
 	Config                       *Config
 	Params                       ConnectionParameters
 	hsCtx                        HandshakeContext
@@ -636,13 +636,13 @@ type ClientStateWaitCertCR struct {
 	serverHandshakeTrafficSecret []byte
 }
 
-var _ HandshakeState = &ClientStateWaitCertCR{}
+var _ HandshakeState = &clientStateWaitCertCR{}
 
-func (state ClientStateWaitCertCR) State() State {
+func (state clientStateWaitCertCR) State() State {
 	return StateClientWaitCertCR
 }
 
-func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -663,7 +663,7 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 	switch body := bodyGeneric.(type) {
 	case *CertificateBody:
 		logf(logTypeHandshake, "[ClientStateWaitCertCR] -> [ClientStateWaitCV]")
-		nextState := ClientStateWaitCV{
+		nextState := clientStateWaitCV{
 			Config:                       state.Config,
 			Params:                       state.Params,
 			hsCtx:                        state.hsCtx,
@@ -686,7 +686,7 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 		state.Params.UsingClientAuth = true
 
 		logf(logTypeHandshake, "[ClientStateWaitCertCR] -> [ClientStateWaitCert]")
-		nextState := ClientStateWaitCert{
+		nextState := clientStateWaitCert{
 			Config:                       state.Config,
 			Params:                       state.Params,
 			hsCtx:                        state.hsCtx,
@@ -703,7 +703,7 @@ func (state ClientStateWaitCertCR) Next(hr handshakeMessageReader) (HandshakeSta
 	return nil, nil, AlertUnexpectedMessage
 }
 
-type ClientStateWaitCert struct {
+type clientStateWaitCert struct {
 	Config        *Config
 	Params        ConnectionParameters
 	hsCtx         HandshakeContext
@@ -717,13 +717,13 @@ type ClientStateWaitCert struct {
 	serverHandshakeTrafficSecret []byte
 }
 
-var _ HandshakeState = &ClientStateWaitCert{}
+var _ HandshakeState = &clientStateWaitCert{}
 
-func (state ClientStateWaitCert) State() State {
+func (state clientStateWaitCert) State() State {
 	return StateClientWaitCert
 }
 
-func (state ClientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -742,7 +742,7 @@ func (state ClientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState
 	state.handshakeHash.Write(hm.Marshal())
 
 	logf(logTypeHandshake, "[ClientStateWaitCert] -> [ClientStateWaitCV]")
-	nextState := ClientStateWaitCV{
+	nextState := clientStateWaitCV{
 		Config:                       state.Config,
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
@@ -757,7 +757,7 @@ func (state ClientStateWaitCert) Next(hr handshakeMessageReader) (HandshakeState
 	return nextState, nil, AlertNoAlert
 }
 
-type ClientStateWaitCV struct {
+type clientStateWaitCV struct {
 	Config        *Config
 	Params        ConnectionParameters
 	hsCtx         HandshakeContext
@@ -772,13 +772,13 @@ type ClientStateWaitCV struct {
 	serverHandshakeTrafficSecret []byte
 }
 
-var _ HandshakeState = &ClientStateWaitCV{}
+var _ HandshakeState = &clientStateWaitCV{}
 
-func (state ClientStateWaitCV) State() State {
+func (state clientStateWaitCV) State() State {
 	return StateClientWaitCV
 }
 
-func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -843,7 +843,7 @@ func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 	state.handshakeHash.Write(hm.Marshal())
 
 	logf(logTypeHandshake, "[ClientStateWaitCV] -> [ClientStateWaitFinished]")
-	nextState := ClientStateWaitFinished{
+	nextState := clientStateWaitFinished{
 		Params:                       state.Params,
 		hsCtx:                        state.hsCtx,
 		cryptoParams:                 state.cryptoParams,
@@ -859,7 +859,7 @@ func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 	return nextState, nil, AlertNoAlert
 }
 
-type ClientStateWaitFinished struct {
+type clientStateWaitFinished struct {
 	Params        ConnectionParameters
 	hsCtx         HandshakeContext
 	cryptoParams  CipherSuiteParams
@@ -875,13 +875,13 @@ type ClientStateWaitFinished struct {
 	serverHandshakeTrafficSecret []byte
 }
 
-var _ HandshakeState = &ClientStateWaitFinished{}
+var _ HandshakeState = &clientStateWaitFinished{}
 
-func (state ClientStateWaitFinished) State() State {
+func (state clientStateWaitFinished) State() State {
 	return StateClientWaitFinished
 }
 
-func (state ClientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state clientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	hm, alert := hr.ReadMessage()
 	if alert != AlertNoAlert {
 		return nil, nil, alert
@@ -1046,7 +1046,7 @@ func (state ClientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeS
 	}...)
 
 	logf(logTypeHandshake, "[ClientStateWaitFinished] -> [StateConnected]")
-	nextState := StateConnected{
+	nextState := stateConnected{
 		Params:              state.Params,
 		hsCtx:               state.hsCtx,
 		isClient:            true,

--- a/conn.go
+++ b/conn.go
@@ -265,7 +265,7 @@ type Conn struct {
 
 	EarlyData []byte
 
-	state             StateConnected
+	state             stateConnected
 	hState            HandshakeState
 	handshakeMutex    sync.Mutex
 	handshakeAlert    Alert
@@ -345,7 +345,7 @@ func (c *Conn) consumeRecord() error {
 			}
 
 			var connected bool
-			c.state, connected = state.(StateConnected)
+			c.state, connected = state.(stateConnected)
 			if !connected {
 				logf(logTypeHandshake, "Disconnected after state transition: %v", alert)
 				c.sendAlert(alert)
@@ -385,7 +385,7 @@ func (c *Conn) consumeRecord() error {
 // Read application data up to the size of buffer.  Handshake and alert records
 // are consumed by the Conn object directly.
 func (c *Conn) Read(buffer []byte) (int, error) {
-	if _, connected := c.hState.(StateConnected); !connected && c.config.NonBlocking {
+	if _, connected := c.hState.(stateConnected); !connected && c.config.NonBlocking {
 		return 0, errors.New("Read called before the handshake completed")
 	}
 	logf(logTypeHandshake, "conn.Read with buffer = %d", len(buffer))
@@ -661,7 +661,7 @@ func (c *Conn) HandshakeSetup() Alert {
 	}
 
 	if c.isClient {
-		state, actions, alert = ClientStateStart{Config: c.config, Opts: opts, hsCtx: c.hsCtx}.Next(nil)
+		state, actions, alert = clientStateStart{Config: c.config, Opts: opts, hsCtx: c.hsCtx}.Next(nil)
 		if alert != AlertNoAlert {
 			logf(logTypeHandshake, "Error initializing client state: %v", alert)
 			return alert
@@ -688,7 +688,7 @@ func (c *Conn) HandshakeSetup() Alert {
 				return AlertInternalError
 			}
 		}
-		state = ServerStateStart{Config: c.config, conn: c, hsCtx: c.hsCtx}
+		state = serverStateStart{Config: c.config, conn: c, hsCtx: c.hsCtx}
 	}
 
 	c.hState = state
@@ -751,7 +751,7 @@ func (c *Conn) Handshake() Alert {
 
 	logf(logTypeHandshake, "(Re-)entering handshake, state=%v", c.hState)
 	state := c.hState
-	_, connected := state.(StateConnected)
+	_, connected := state.(stateConnected)
 
 	hmr := &handshakeMessageReaderImpl{hsCtx: &c.hsCtx}
 	for !connected {
@@ -784,9 +784,9 @@ func (c *Conn) Handshake() Alert {
 
 		c.hState = state
 		logf(logTypeHandshake, "state is now %s", c.GetHsState())
-		_, connected = state.(StateConnected)
+		_, connected = state.(stateConnected)
 		if connected {
-			c.state = state.(StateConnected)
+			c.state = state.(stateConnected)
 			c.handshakeComplete = true
 		}
 
@@ -852,7 +852,7 @@ func (c *Conn) GetHsState() State {
 }
 
 func (c *Conn) ComputeExporter(label string, context []byte, keyLength int) ([]byte, error) {
-	_, connected := c.hState.(StateConnected)
+	_, connected := c.hState.(stateConnected)
 	if !connected {
 		return nil, fmt.Errorf("Cannot compute exporter when state is not connected")
 	}

--- a/state-machine.go
+++ b/state-machine.go
@@ -81,8 +81,8 @@ func (hc *HandshakeContext) SetVersion(version uint16) {
 	}
 }
 
-// StateConnected is symmetric between client and server
-type StateConnected struct {
+// stateConnected is symmetric between client and server
+type stateConnected struct {
 	Params              ConnectionParameters
 	hsCtx               HandshakeContext
 	isClient            bool
@@ -95,16 +95,16 @@ type StateConnected struct {
 	verifiedChains      [][]*x509.Certificate
 }
 
-var _ HandshakeState = &StateConnected{}
+var _ HandshakeState = &stateConnected{}
 
-func (state StateConnected) State() State {
+func (state stateConnected) State() State {
 	if state.isClient {
 		return StateClientConnected
 	}
 	return StateServerConnected
 }
 
-func (state *StateConnected) KeyUpdate(request KeyUpdateRequest) ([]HandshakeAction, Alert) {
+func (state *stateConnected) KeyUpdate(request KeyUpdateRequest) ([]HandshakeAction, Alert) {
 	var trafficKeys keySet
 	if state.isClient {
 		state.clientTrafficSecret = HkdfExpandLabel(state.cryptoParams.Hash, state.clientTrafficSecret,
@@ -130,7 +130,7 @@ func (state *StateConnected) KeyUpdate(request KeyUpdateRequest) ([]HandshakeAct
 	return toSend, AlertNoAlert
 }
 
-func (state *StateConnected) NewSessionTicket(length int, lifetime, earlyDataLifetime uint32) ([]HandshakeAction, Alert) {
+func (state *stateConnected) NewSessionTicket(length int, lifetime, earlyDataLifetime uint32) ([]HandshakeAction, Alert) {
 	tkt, err := NewSessionTicket(length, lifetime)
 	if err != nil {
 		logf(logTypeHandshake, "[StateConnected] Error generating NewSessionTicket: %v", err)
@@ -172,11 +172,11 @@ func (state *StateConnected) NewSessionTicket(length int, lifetime, earlyDataLif
 }
 
 // Next does nothing for this state.
-func (state StateConnected) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
+func (state stateConnected) Next(hr handshakeMessageReader) (HandshakeState, []HandshakeAction, Alert) {
 	return state, nil, AlertNoAlert
 }
 
-func (state StateConnected) ProcessMessage(hm *HandshakeMessage) (HandshakeState, []HandshakeAction, Alert) {
+func (state stateConnected) ProcessMessage(hm *HandshakeMessage) (HandshakeState, []HandshakeAction, Alert) {
 	if hm == nil {
 		logf(logTypeHandshake, "[StateConnected] Unexpected message")
 		return nil, nil, AlertUnexpectedMessage

--- a/state-machine_test.go
+++ b/state-machine_test.go
@@ -70,20 +70,20 @@ func TestStateMachineIntegration(t *testing.T) {
 					CookieProtector:  cookieProtector,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitCertCR{},
-					ClientStateWaitCV{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitCertCR{},
+					clientStateWaitCV{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -111,23 +111,23 @@ func TestStateMachineIntegration(t *testing.T) {
 					CookieProtector:  cookieProtector,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitCertCR{},
-					ClientStateWaitCV{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitCertCR{},
+					clientStateWaitCV{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -158,18 +158,18 @@ func TestStateMachineIntegration(t *testing.T) {
 					Certificates: certificates,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -202,19 +202,19 @@ func TestStateMachineIntegration(t *testing.T) {
 					AllowEarlyData: true,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitEOED{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitEOED{},
+					serverStateWaitFlight2{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -243,20 +243,20 @@ func TestStateMachineIntegration(t *testing.T) {
 					Certificates:     certificates,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitCertCR{},
-					ClientStateWaitCV{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitCertCR{},
+					clientStateWaitCV{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -285,23 +285,23 @@ func TestStateMachineIntegration(t *testing.T) {
 					RequireClientAuth: true,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitCertCR{},
-					ClientStateWaitCert{},
-					ClientStateWaitCV{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitCertCR{},
+					clientStateWaitCert{},
+					clientStateWaitCV{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitCert{},
-					ServerStateWaitCV{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitCert{},
+					serverStateWaitCV{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 
@@ -329,22 +329,22 @@ func TestStateMachineIntegration(t *testing.T) {
 					RequireClientAuth: true,
 				},
 				clientStateSequence: []HandshakeState{
-					ClientStateStart{},
-					ClientStateWaitSH{},
-					ClientStateWaitEE{},
-					ClientStateWaitCertCR{},
-					ClientStateWaitCert{},
-					ClientStateWaitCV{},
-					ClientStateWaitFinished{},
-					StateConnected{},
+					clientStateStart{},
+					clientStateWaitSH{},
+					clientStateWaitEE{},
+					clientStateWaitCertCR{},
+					clientStateWaitCert{},
+					clientStateWaitCV{},
+					clientStateWaitFinished{},
+					stateConnected{},
 				},
 				serverStateSequence: []HandshakeState{
-					ServerStateStart{},
-					ServerStateNegotiated{},
-					ServerStateWaitFlight2{},
-					ServerStateWaitCert{},
-					ServerStateWaitFinished{},
-					StateConnected{},
+					serverStateStart{},
+					serverStateNegotiated{},
+					serverStateWaitFlight2{},
+					serverStateWaitCert{},
+					serverStateWaitFinished{},
+					stateConnected{},
 				},
 			},
 		}
@@ -359,12 +359,12 @@ func TestStateMachineIntegration(t *testing.T) {
 			chsCtx.SetVersion(tls10Version)
 			shsCtx := chsCtx
 			var clientState, serverState HandshakeState
-			clientState = ClientStateStart{
+			clientState = clientStateStart{
 				Config: params.clientConfig,
 				Opts:   params.clientOptions,
 				hsCtx:  chsCtx,
 			}
-			serverState = ServerStateStart{Config: params.serverConfig, hsCtx: shsCtx}
+			serverState = serverStateStart{Config: params.serverConfig, hsCtx: shsCtx}
 
 			t.Logf("Client: %s", reflect.TypeOf(clientState).Name())
 			t.Logf("Server: %s", reflect.TypeOf(serverState).Name())
@@ -389,7 +389,7 @@ func TestStateMachineIntegration(t *testing.T) {
 
 				// Client -> Server
 				for {
-					if _, connected := serverState.(StateConnected); connected {
+					if _, connected := serverState.(stateConnected); connected {
 						break
 					}
 					var nextState HandshakeState
@@ -407,7 +407,7 @@ func TestStateMachineIntegration(t *testing.T) {
 
 				// Server -> Client
 				for {
-					if _, connected := clientState.(StateConnected); connected {
+					if _, connected := clientState.(stateConnected); connected {
 						break
 					}
 					var nextState HandshakeState
@@ -423,11 +423,11 @@ func TestStateMachineIntegration(t *testing.T) {
 					serverHandshakeMessageReader.queue = append(serverHandshakeMessageReader.queue, clientResponses...)
 				}
 
-				clientConnected := reflect.TypeOf(clientState) == reflect.TypeOf(StateConnected{})
-				serverConnected := reflect.TypeOf(serverState) == reflect.TypeOf(StateConnected{})
+				clientConnected := reflect.TypeOf(clientState) == reflect.TypeOf(stateConnected{})
+				serverConnected := reflect.TypeOf(serverState) == reflect.TypeOf(stateConnected{})
 				if clientConnected && serverConnected {
-					c := clientState.(StateConnected)
-					s := serverState.(StateConnected)
+					c := clientState.(stateConnected)
+					s := serverState.(stateConnected)
 
 					// Test that we ended up at the same state
 					assertDeepEquals(t, c.Params, s.Params)


### PR DESCRIPTION
This PR privatizes all handshake states, thereby reducing our [public API](https://godoc.org/github.com/bifurcation/mint) by roughly 20%.

In general, I think we should only expose objects and functions that are actually needed to interact with mint. There is **a lot** more that we can privatize, so this PR is just a small step in this direction. If we agree that this is the path we want to go, I'll be happy to contribute more PRs.

@bifurcation, @ekr: What do you think?