### PR TITLE
expose the peer certificates and the verified chain in the connection state

### DIFF
--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -853,6 +853,8 @@ func (state ClientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 		masterSecret:                 state.masterSecret,
 		clientHandshakeTrafficSecret: state.clientHandshakeTrafficSecret,
 		serverHandshakeTrafficSecret: state.serverHandshakeTrafficSecret,
+		peerCertificates:             certs,
+		verifiedChains:               verifiedChains,
 	}
 	return nextState, nil, AlertNoAlert
 }
@@ -865,6 +867,8 @@ type ClientStateWaitFinished struct {
 
 	certificates             []*Certificate
 	serverCertificateRequest *CertificateRequestBody
+	peerCertificates         []*x509.Certificate
+	verifiedChains           [][]*x509.Certificate
 
 	masterSecret                 []byte
 	clientHandshakeTrafficSecret []byte
@@ -1051,6 +1055,8 @@ func (state ClientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeS
 		clientTrafficSecret: clientTrafficSecret,
 		serverTrafficSecret: serverTrafficSecret,
 		exporterSecret:      exporterSecret,
+		peerCertificates:    state.peerCertificates,
+		verifiedChains:      state.verifiedChains,
 	}
 	return nextState, toSend, AlertNoAlert
 }

--- a/conn.go
+++ b/conn.go
@@ -890,7 +890,7 @@ func (c *Conn) ComputeExporter(label string, context []byte, keyLength int) ([]b
 	return HkdfExpandLabel(c.state.cryptoParams.Hash, tmpSecret, "exporter", hc, keyLength), nil
 }
 
-func (c *Conn) State() ConnectionState {
+func (c *Conn) ConnectionState() ConnectionState {
 	state := ConnectionState{
 		HandshakeState: c.GetHsState(),
 	}

--- a/conn.go
+++ b/conn.go
@@ -271,9 +271,10 @@ var (
 
 type ConnectionState struct {
 	HandshakeState   State
-	CipherSuite      CipherSuiteParams   // cipher suite in use (TLS_RSA_WITH_RC4_128_SHA, ...)
-	PeerCertificates []*x509.Certificate // certificate chain presented by remote peer TODO(ekr@rtfm.com): implement
-	NextProto        string              // Selected ALPN proto
+	CipherSuite      CipherSuiteParams     // cipher suite in use (TLS_RSA_WITH_RC4_128_SHA, ...)
+	PeerCertificates []*x509.Certificate   // certificate chain presented by remote peer
+	VerifiedChains   [][]*x509.Certificate // verified chains built from PeerCertificates
+	NextProto        string                // Selected ALPN proto
 }
 
 // Conn implements the net.Conn interface, as with "crypto/tls"
@@ -897,6 +898,8 @@ func (c *Conn) State() ConnectionState {
 	if c.handshakeComplete {
 		state.CipherSuite = cipherSuiteMap[c.state.Params.CipherSuite]
 		state.NextProto = c.state.Params.NextProto
+		state.VerifiedChains = c.state.verifiedChains
+		state.PeerCertificates = c.state.peerCertificates
 	}
 
 	return state

--- a/conn_test.go
+++ b/conn_test.go
@@ -1155,8 +1155,8 @@ func TestConnectionState(t *testing.T) {
 	assertEquals(t, clientAlert, AlertNoAlert)
 	<-done
 
-	clientCS := client.State()
-	serverCS := server.State()
+	clientCS := client.ConnectionState()
+	serverCS := server.ConnectionState()
 	assertEquals(t, clientCS.CipherSuite.Suite, configClient.CipherSuites[0])
 	assertDeepEquals(t, clientCS.VerifiedChains, [][]*x509.Certificate{{serverCert}})
 	assertDeepEquals(t, clientCS.PeerCertificates, []*x509.Certificate{serverCert})

--- a/state-machine.go
+++ b/state-machine.go
@@ -1,6 +1,7 @@
 package mint
 
 import (
+	"crypto/x509"
 	"time"
 )
 
@@ -90,6 +91,8 @@ type StateConnected struct {
 	clientTrafficSecret []byte
 	serverTrafficSecret []byte
 	exporterSecret      []byte
+	peerCertificates    []*x509.Certificate
+	verifiedChains      [][]*x509.Certificate
 }
 
 var _ HandshakeState = &StateConnected{}


### PR DESCRIPTION
Depends on #172. Fixes #81. Closes #162.

This is a better version of #162, and it's probably the better way to first implement all the verification logic.

The behavior should be analogous to the Go standard library.
I also renamed the `Conn.State()` to `Conn.ConnectionState()`, to make mint more consistent with the `tls.Conn` from the standard library.