### PR TITLE
Restore self signing utils

### DIFF
--- a/bin/mint-client-https/main.go
+++ b/bin/mint-client-https/main.go
@@ -12,12 +12,20 @@ import (
 )
 
 var url string
+var dontValidate bool
 
 func main() {
+	c := mint.Config{}
+
 	url := flag.String("url", "https://localhost:4430", "URL to send request")
+	flag.BoolVar(&dontValidate, "dontvalidate", false, "don't validate certs")
 	flag.Parse()
+	if dontValidate {
+		c.InsecureSkipVerify = true
+	}
+
 	mintdial := func(network, addr string) (net.Conn, error) {
-		return mint.Dial(network, addr, nil)
+		return mint.Dial(network, addr, &c)
 	}
 
 	tr := &http.Transport{

--- a/bin/mint-client/main.go
+++ b/bin/mint-client/main.go
@@ -9,17 +9,23 @@ import (
 
 var addr string
 var dtls bool
+var dontValidate bool
 
 func main() {
+	c := mint.Config{}
+
 	flag.StringVar(&addr, "addr", "localhost:4430", "port")
 	flag.BoolVar(&dtls, "dtls", false, "use DTLS")
+	flag.BoolVar(&dontValidate, "dontvalidate", false, "don't validate certs")
 	flag.Parse()
-
+	if dontValidate {
+		c.InsecureSkipVerify = true
+	}
 	network := "tcp"
 	if dtls {
 		network = "udp"
 	}
-	conn, err := mint.Dial(network, addr, nil)
+	conn, err := mint.Dial(network, addr, &c)
 
 	if err != nil {
 		fmt.Println("TLS handshake failed:", err)

--- a/bin/mint-server-https/main.go
+++ b/bin/mint-server-https/main.go
@@ -153,6 +153,12 @@ func main() {
 		log.Fatalf("Error: %v", err)
 	}
 
+	if certFile == "" && keyFile == "" {
+		var cert *x509.Certificate
+		priv, cert, err = mint.MakeNewSelfSignedCert(serverName, mint.RSA_PKCS1_SHA256)
+		certChain = []*x509.Certificate{cert}
+
+	}
 	// Load response file
 	if responseFile != "" {
 		log.Printf("Loading response file: %v", responseFile)
@@ -177,15 +183,16 @@ func main() {
 
 	config.SendSessionTickets = sendTickets
 
-	if certChain != nil && priv != nil {
+	if certFile != "" && keyFile != "" {
 		log.Printf("Loading cert: %v key: %v", certFile, keyFile)
-		config.Certificates = []*mint.Certificate{
-			{
-				Chain:      certChain,
-				PrivateKey: priv,
-			},
-		}
 	}
+	config.Certificates = []*mint.Certificate{
+		{
+			Chain:      certChain,
+			PrivateKey: priv,
+		},
+	}
+
 	config.Init(false)
 
 	service := "0.0.0.0:" + port

--- a/bin/mint-server-https/main.go
+++ b/bin/mint-server-https/main.go
@@ -25,6 +25,7 @@ var (
 	responseFile string
 	h2           bool
 	sendTickets  bool
+	genCert      bool
 )
 
 type responder []byte
@@ -113,6 +114,7 @@ func main() {
 	flag.StringVar(&serverName, "host", "example.com", "hostname")
 	flag.StringVar(&certFile, "cert", "", "certificate chain in PEM or DER")
 	flag.StringVar(&keyFile, "key", "", "private key in PEM format")
+	flag.BoolVar(&genCert, "gencert", false, "generate a self-signed cert")
 	flag.StringVar(&responseFile, "response", "", "file to serve")
 	flag.BoolVar(&h2, "h2", false, "whether to use HTTP/2 (exclusively)")
 	flag.BoolVar(&sendTickets, "tickets", true, "whether to send session tickets")
@@ -123,8 +125,14 @@ func main() {
 	var response []byte
 	var err error
 
-	// Load the key and certificate chain
 	if certFile != "" {
+		if keyFile == "" {
+			log.Fatalf("Can't specify -cert without -key")
+		}
+		if genCert {
+			log.Fatalf("Can't specify -cert and -gencert together")
+		}
+
 		certs, err := ioutil.ReadFile(certFile)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
@@ -137,8 +145,7 @@ func main() {
 				}
 			}
 		}
-	}
-	if keyFile != "" {
+
 		keyPEM, err := ioutil.ReadFile(keyFile)
 		if err != nil {
 			log.Fatalf("Error: %v", err)
@@ -148,17 +155,21 @@ func main() {
 				log.Fatalf("Error parsing private key: %v", err)
 			}
 		}
-	}
-	if err != nil {
-		log.Fatalf("Error: %v", err)
-	}
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+	} else if genCert {
+		if keyFile != "" {
+			log.Fatalf("Can't specify -gencert and -key together")
+		}
 
-	if certFile == "" && keyFile == "" {
 		var cert *x509.Certificate
 		priv, cert, err = mint.MakeNewSelfSignedCert(serverName, mint.RSA_PKCS1_SHA256)
 		certChain = []*x509.Certificate{cert}
-
+	} else {
+		log.Fatalf("Must provide either -gencert or -key, -cert")
 	}
+
 	// Load response file
 	if responseFile != "" {
 		log.Printf("Loading response file: %v", responseFile)

--- a/bin/mint-server/main.go
+++ b/bin/mint-server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/x509"
 	"flag"
 	"log"
 	"net"
@@ -14,6 +15,13 @@ func main() {
 	var config mint.Config
 	config.SendSessionTickets = true
 	config.ServerName = "localhost"
+	priv, cert, err := mint.MakeNewSelfSignedCert("localhost", mint.RSA_PKCS1_SHA256)
+	config.Certificates = []*mint.Certificate{
+		{
+			Chain:      []*x509.Certificate{cert},
+			PrivateKey: priv,
+		},
+	}
 	config.Init(false)
 
 	flag.StringVar(&port, "port", "4430", "port")

--- a/conn_test.go
+++ b/conn_test.go
@@ -145,11 +145,11 @@ const (
 
 func init() {
 	var err error
-	serverKey, serverCert, err = MakeNewSelfSignedCert(serverName, RSA_PKCS1_SHA256)
+	serverKey, serverCert, err = MakeNewSelfSignedCert(serverName, ECDSA_P256_SHA256)
 	if err != nil {
 		panic(err)
 	}
-	clientKey, clientCert, err = MakeNewSelfSignedCert(clientName, RSA_PKCS1_SHA256)
+	clientKey, clientCert, err = MakeNewSelfSignedCert(clientName, ECDSA_P256_SHA256)
 	if err != nil {
 		panic(err)
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -11,9 +11,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
 	"math/big"
+	"time"
 
 	"golang.org/x/crypto/curve25519"
 
@@ -615,4 +617,51 @@ func makeTrafficKeys(params CipherSuiteParams, secret []byte) keySet {
 		key:    HkdfExpandLabel(params.Hash, secret, "key", []byte{}, params.KeyLen),
 		iv:     HkdfExpandLabel(params.Hash, secret, "iv", []byte{}, params.IvLen),
 	}
+}
+
+func MakeNewSelfSignedCert(name string, alg SignatureScheme) (crypto.Signer, *x509.Certificate, error) {
+	priv, err := newSigningKey(alg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := newSelfSigned(name, alg, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	return priv, cert, nil
+}
+
+func newSelfSigned(name string, alg SignatureScheme, priv crypto.Signer) (*x509.Certificate, error) {
+	sigAlg, ok := x509AlgMap[alg]
+	if !ok {
+		return nil, fmt.Errorf("tls.selfsigned: Unknown signature algorithm [%04x]", alg)
+	}
+	if len(name) == 0 {
+		return nil, fmt.Errorf("tls.selfsigned: No name provided")
+	}
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(0xA0A0A0A0))
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:       serial,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().AddDate(0, 0, 1),
+		SignatureAlgorithm: sigAlg,
+		Subject:            pkix.Name{CommonName: name},
+		DNSNames:           []string{name},
+		KeyUsage:           x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(prng, template, template, priv.Public(), priv)
+	if err != nil {
+		return nil, err
+	}
+
+	// It is safe to ignore the error here because we're parsing known-good data
+	cert, _ := x509.ParseCertificate(der)
+	return cert, nil
 }

--- a/negotiation_test.go
+++ b/negotiation_test.go
@@ -117,20 +117,20 @@ func TestPSKModeNegotiation(t *testing.T) {
 func TestCertificateSelection(t *testing.T) {
 	goodName := "example.com"
 	badName := "not-example.com"
-	rsa := []SignatureScheme{RSA_PKCS1_SHA256}
+	rsa := []SignatureScheme{ECDSA_P256_SHA256}
 	eddsa := []SignatureScheme{Ed25519}
 
 	// Test success
 	cert, scheme, err := CertificateSelection(&goodName, rsa, certificates)
 	assertNotError(t, err, "Failed to find certificate in a valid set")
 	assertNotNil(t, cert, "Failed to set certificate")
-	assertEquals(t, scheme, RSA_PKCS1_SHA256)
+	assertEquals(t, scheme, ECDSA_P256_SHA256)
 
 	// Test success with no name specified
 	cert, scheme, err = CertificateSelection(nil, rsa, certificates)
 	assertNotError(t, err, "Failed to find certificate in a valid set")
 	assertNotNil(t, cert, "Failed to set certificate")
-	assertEquals(t, scheme, RSA_PKCS1_SHA256)
+	assertEquals(t, scheme, ECDSA_P256_SHA256)
 
 	// Test failure on no certs matching host name
 	_, _, err = CertificateSelection(&badName, rsa, certificates)

--- a/state-machine_test.go
+++ b/state-machine_test.go
@@ -50,7 +50,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"normal": {
 				clientConfig: &Config{
 					Groups:             []NamedGroup{P256},
-					SignatureSchemes:   []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:   []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:           []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:       []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:               &PSKMapCache{},
@@ -62,7 +62,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:             &PSKMapCache{},
@@ -90,7 +90,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"helloRetryRequest": {
 				clientConfig: &Config{
 					Groups:             []NamedGroup{P256},
-					SignatureSchemes:   []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:   []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:           []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:       []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:               &PSKMapCache{},
@@ -102,7 +102,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:             &PSKMapCache{},
@@ -135,7 +135,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"psk": {
 				clientConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs: &PSKMapCache{
@@ -149,7 +149,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs: &PSKMapCache{
@@ -177,7 +177,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"pskWithEarlyData": {
 				clientConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs: &PSKMapCache{
@@ -192,7 +192,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs: &PSKMapCache{
@@ -222,7 +222,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"pskRejected": {
 				clientConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs: &PSKMapCache{
@@ -236,7 +236,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:           []NamedGroup{P256},
-					SignatureSchemes: []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes: []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:         []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:     []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:             &PSKMapCache{},
@@ -264,7 +264,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"clientAuth": {
 				clientConfig: &Config{
 					Groups:             []NamedGroup{P256},
-					SignatureSchemes:   []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:   []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:           []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:       []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:               &PSKMapCache{},
@@ -277,7 +277,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:            []NamedGroup{P256},
-					SignatureSchemes:  []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:  []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:          []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:      []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:              &PSKMapCache{},
@@ -309,7 +309,7 @@ func TestStateMachineIntegration(t *testing.T) {
 			"clientAuthNoCertificate": {
 				clientConfig: &Config{
 					Groups:             []NamedGroup{P256},
-					SignatureSchemes:   []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:   []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:           []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:       []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:               &PSKMapCache{},
@@ -321,7 +321,7 @@ func TestStateMachineIntegration(t *testing.T) {
 				},
 				serverConfig: &Config{
 					Groups:            []NamedGroup{P256},
-					SignatureSchemes:  []SignatureScheme{RSA_PSS_SHA256},
+					SignatureSchemes:  []SignatureScheme{ECDSA_P256_SHA256},
 					PSKModes:          []PSKKeyExchangeMode{PSKModeDHEKE},
 					CipherSuites:      []CipherSuite{TLS_AES_128_GCM_SHA256},
 					PSKs:              &PSKMapCache{},


### PR DESCRIPTION
This PR cleans up fallout from PR#167 and PR#170. Specifically:

1. Exposes a public MakeNewSelfSignedCert API because need that several places.
2. Modifies the server programs so that they explicitly call the new API (otherwise they don't work).
3. Adds a flag to the clients to skip cert verification.

In future, it would help if we were more careful