### PR TITLE
The API needs to throw an error whenever you try to Read() before the

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -385,7 +385,7 @@ func (c *Conn) consumeRecord() error {
 // Read application data up to the size of buffer.  Handshake and alert records
 // are consumed by the Conn object directly.
 func (c *Conn) Read(buffer []byte) (int, error) {
-	if _, connected := c.hState.(StateConnected); !connected && c.config.NonBlocking {
+	if _, connected := c.hState.(StateConnected); !connected {
 		return 0, errors.New("Read called before the handshake completed")
 	}
 	logf(logTypeHandshake, "conn.Read with buffer = %d", len(buffer))


### PR DESCRIPTION
handshake is complete, non-blocking mode or not.