### PR TITLE
WIP: SPAKE2

### DIFF
--- a/common.go
+++ b/common.go
@@ -147,6 +147,14 @@ const (
 	FFDHE8192 NamedGroup = 260
 )
 
+// No TLS syntax, used internally
+type PasswordHash uint8
+
+const (
+	PasswordHashScrypt PasswordHash = iota
+	PasswordHashArgon2
+)
+
 // enum {...} PskKeyExchangeMode;
 type PSKKeyExchangeMode uint8
 

--- a/common.go
+++ b/common.go
@@ -125,6 +125,7 @@ const (
 	ExtensionTypeCookie              ExtensionType = 44
 	ExtensionTypePSKKeyExchangeModes ExtensionType = 45
 	ExtensionTypeTicketEarlyDataInfo ExtensionType = 46
+	ExtensionTypeSPAKE2              ExtensionType = 47 // XXX(rlb@ipv.sx): Unassigned
 )
 
 // enum {...} NamedGroup

--- a/conn.go
+++ b/conn.go
@@ -62,6 +62,33 @@ func (cache PSKMapCache) Size() int {
 	return len(cache)
 }
 
+type Password struct {
+	Group    NamedGroup
+	Identity string
+	Password []byte
+}
+
+type PasswordCache interface {
+	Get(string) (Password, bool)
+	Put(Password)
+	Size() int
+}
+
+type PasswordMapCache map[string]Password
+
+func (cache PasswordMapCache) Get(identity string) (pw Password, ok bool) {
+	pw, ok = cache[identity]
+	return
+}
+
+func (cache *PasswordMapCache) Put(identity string, pw Password) {
+	(*cache)[pw.Identity] = pw
+}
+
+func (cache PasswordMapCache) Size() int {
+	return len(cache)
+}
+
 // Config is the struct used to pass configuration settings to a TLS client or
 // server instance.  The settings for client and server are pretty different,
 // but we just throw them all in here.

--- a/conn.go
+++ b/conn.go
@@ -63,9 +63,12 @@ func (cache PSKMapCache) Size() int {
 }
 
 type Password struct {
-	Group    NamedGroup
-	Identity string
-	Password []byte
+	Identity     string
+	Group        NamedGroup
+	Hash         PasswordHash // Should only be provided for client
+	Password     []byte       // Should only be provided for client
+	PasswordHash []byte       // w0; should only be provided for server
+	Point        []byte       // L; should only be provided for server
 }
 
 type PasswordCache interface {

--- a/conn_test.go
+++ b/conn_test.go
@@ -910,7 +910,7 @@ func Test0xRTT(t *testing.T) {
 	runParametrizedTest(t, params, test0xRTT)
 }
 
-func testSPAKE2(t *testing.T, name string, p testInstanceState) {
+func testSPAKE2HS(t *testing.T, name string, p testInstanceState) {
 	conf := *spake2Config
 	conf.NonBlocking = true
 
@@ -937,7 +937,7 @@ func TestSPAKE2HS(t *testing.T) {
 	params := map[string][]string{
 		"dtls": {"true", "false"},
 	}
-	runParametrizedTest(t, params, testSPAKE2)
+	runParametrizedTest(t, params, testSPAKE2HS)
 }
 
 func Test0xRTTFailure(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -100,7 +100,6 @@ func (b *bufferedConn) Write(buf []byte) (int, error) {
 	ctr := b.writeCounter
 	b.writeCounter++
 	if b.lostWrite[ctr] {
-		fmt.Println("Losing write ", ctr)
 		return 0, nil
 	}
 

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -126,10 +126,10 @@ var (
 
 	// SPAKE2 test cases
 	spake2ClientHex = "000c" + "000400010203" + "000404050607"
-	spake2ServerHex = "fffe" + "000408090a0b"
+	spake2ServerHex = "000408090a0b" + "00040c0d0e0f"
 	spake2ClientIn  = &SPAKE2Extension{
 		HandshakeType: HandshakeTypeClientHello,
-		Shares: []SPAKE2Share{
+		KeyShares: []SPAKE2Share{
 			{
 				Identity:    []byte{0, 1, 2, 3},
 				KeyExchange: []byte{4, 5, 6, 7},
@@ -137,12 +137,11 @@ var (
 		},
 	}
 	spake2ServerIn = &SPAKE2Extension{
-		HandshakeType:    HandshakeTypeServerHello,
-		SelectedIdentity: 0xfffe,
-		Shares: []SPAKE2Share{
+		HandshakeType: HandshakeTypeServerHello,
+		KeyShares: []SPAKE2Share{
 			{
-				Identity:    nil,
-				KeyExchange: []byte{8, 9, 10, 11},
+				Identity:    []byte{8, 9, 10, 11},
+				KeyExchange: []byte{12, 13, 14, 15},
 			},
 		},
 	}

--- a/negotiation.go
+++ b/negotiation.go
@@ -229,17 +229,17 @@ func PasswordNegotiation(keyShares []SPAKE2Share, passwords PasswordCache) (bool
 			return false, nil, nil, nil, nil
 		}
 
-		priv, pub, err := newSPAKE2KeyShare(password.Group, false, password.Password)
+		priv, pub, err := newSPAKE2KeyShare(password.Group, false, password.PasswordHash)
 		if err != nil {
 			continue
 		}
 
-		spake2Secret, err := spake2KeyAgreement(password.Group, false, share.KeyExchange, priv, password.Password)
+		Z, V, err := spake2pServer(password.Group, share.KeyExchange, priv, password.PasswordHash, password.Point)
 		if err != nil {
 			continue
 		}
 
-		return true, share.Identity, pub, spake2Secret, password.Password
+		return true, share.Identity, pub, Z, V
 	}
 
 	return false, nil, nil, nil, nil

--- a/negotiation_test.go
+++ b/negotiation_test.go
@@ -99,19 +99,28 @@ func TestPSKNegotiation(t *testing.T) {
 
 func TestPSKModeNegotiation(t *testing.T) {
 	// Test that everything that's allowed gets used
-	usingDH, usingPSK := PSKModeNegotiation(true, true, []PSKKeyExchangeMode{PSKModeKE, PSKModeDHEKE})
+	usingDH, usingPSK, usingSPAKE2 := PSKModeNegotiation(true, true, false, []PSKKeyExchangeMode{PSKModeKE, PSKModeDHEKE})
 	assertTrue(t, usingDH, "Unnecessarily disabled DH")
 	assertTrue(t, usingPSK, "Unnecessarily disabled PSK")
+	assertTrue(t, !usingSPAKE2, "Should not have enabled SPAKE2")
 
 	// Test that DH is disabled when not allowed with the PSK
-	usingDH, usingPSK = PSKModeNegotiation(true, true, []PSKKeyExchangeMode{PSKModeKE})
+	usingDH, usingPSK, usingSPAKE2 = PSKModeNegotiation(true, true, false, []PSKKeyExchangeMode{PSKModeKE})
 	assertTrue(t, !usingDH, "Should not have enabled DH")
 	assertTrue(t, usingPSK, "Unnecessarily disabled PSK")
+	assertTrue(t, !usingSPAKE2, "Should not have enabled SPAKE2")
 
 	// Test that the PSK is disabled when DH is required but not possible
-	usingDH, usingPSK = PSKModeNegotiation(false, true, []PSKKeyExchangeMode{PSKModeDHEKE})
+	usingDH, usingPSK, usingSPAKE2 = PSKModeNegotiation(false, true, false, []PSKKeyExchangeMode{PSKModeDHEKE})
 	assertTrue(t, !usingDH, "Should not have enabled DH")
 	assertTrue(t, !usingPSK, "Should not have enabled PSK")
+	assertTrue(t, !usingSPAKE2, "Should not have enabled SPAKE2")
+
+	// Test that SPAKE2 overrides everything else
+	usingDH, usingPSK, usingSPAKE2 = PSKModeNegotiation(true, true, true, []PSKKeyExchangeMode{PSKModeKE, PSKModeDHEKE})
+	assertTrue(t, !usingDH, "Should not have enabled DH")
+	assertTrue(t, !usingPSK, "Should not have enabled PSK")
+	assertTrue(t, usingSPAKE2, "Unnecessarily disabled SPAKE2")
 }
 
 func TestCertificateSelection(t *testing.T) {

--- a/spake2.go
+++ b/spake2.go
@@ -1,0 +1,145 @@
+package mint
+
+import (
+	"crypto/elliptic"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+)
+
+const (
+	M256hex = "04" +
+		"886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f" +
+		"5ff355163e43ce224e0b0e65ff02ac8e5c7be09419c785e0ca547d55a12e2d20"
+	N256hex = "04" +
+		"d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b49" +
+		"07d60aa6bfade45008a636337f5168c64d9bd36034808cd564490b1e656edbe7"
+	M384hex = "04" +
+		"0ff0895ae5ebf6187080a82d82b42e2765e3b2f8749c7e05eba366434b363d3dc36f15314739074d2eb8613fceec2853" +
+		"97592c55797cdd77c0715cb7df2150220a0119866486af4234f390aad1f6addde5930909adc67a1fc0c99ba3d52dc5dd"
+	N384hex = "04" +
+		"c72cf2e390853a1c1c4ad816a62fd15824f56078918f43f922ca21518f9c543bb252c5490214cf9aa3f0baab4b665c10" +
+		"c38b7d7f4e7f320317cd717315a797c7e02933aef68b364cbf84ebc619bedbe21ff5c69ea0f1fed5d7e3200418073f40"
+	M521hex = "04" +
+		"003f06f38131b2ba2600791e82488e8d20ab889af753a41806c5db18d37d85608c" +
+		"fae06b82e4a72cd744c719193562a653ea1f119eef9356907edc9b56979962d7aa" +
+		"01bdd179a3d547610892e9b96dea1eab10bdd7ac5ae0cf75aa0f853bfd185cf782" +
+		"f894301998b11d1898ede2701dca37a2bb50b4f519c3d89a7d054b51fb84912192"
+	N521hex = "04" +
+		"00c7924b9ec017f3094562894336a53c50167ba8c5963876880542bc669e494b25" +
+		"32d76c5b53dfb349fdf69154b9e0048c58a42e8ed04cef052a3bc349d95575cd25" +
+		"01c62bee650c9287a651bb75c7f39a2006873347b769840d261d17760b107e29f0" +
+		"91d556a82a2e4cde0c40b84b95b878db2489ef760206424b3fe7968aa8e0b1f334"
+)
+
+var (
+	M256x, M256y *big.Int
+	N256x, N256y *big.Int
+	M384x, M384y *big.Int
+	N384x, N384y *big.Int
+	M521x, M521y *big.Int
+	N521x, N521y *big.Int
+)
+
+func init() {
+	p256 := elliptic.P256()
+	p384 := elliptic.P384()
+	p521 := elliptic.P521()
+
+	M256, _ := hex.DecodeString(M256hex)
+	N256, _ := hex.DecodeString(N256hex)
+	M384, _ := hex.DecodeString(M384hex)
+	N384, _ := hex.DecodeString(N384hex)
+	M521, _ := hex.DecodeString(M521hex)
+	N521, _ := hex.DecodeString(N521hex)
+
+	M256x, M256y = elliptic.Unmarshal(p256, M256)
+	N256x, N256y = elliptic.Unmarshal(p256, N256)
+	M384x, M384y = elliptic.Unmarshal(p384, M384)
+	N384x, N384y = elliptic.Unmarshal(p384, N384)
+	M521x, M521y = elliptic.Unmarshal(p521, M521)
+	N521x, N521y = elliptic.Unmarshal(p521, N521)
+}
+
+func spakeBasePoint(group NamedGroup, client bool) (x, y *big.Int) {
+	switch group {
+	case P256:
+		if client {
+			return M256x, M256y
+		} else {
+			return N256x, N256y
+		}
+	case P384:
+		if client {
+			return M384x, M384y
+		} else {
+			return N384x, N384y
+		}
+	case P521:
+		if client {
+			return M521x, M521y
+		} else {
+			return N521x, N521y
+		}
+	default:
+		panic("This should be pre-filtered by SPAKE functions")
+	}
+}
+
+// Generate an ephemeral `x` and return `w * M + x * G` (or the
+// appropriate server-side equivalents)
+func newSPAKE2KeyShare(group NamedGroup, client bool, w []byte) (x, T []byte, err error) {
+	switch group {
+	case P256, P384, P521:
+		crv := curveFromNamedGroup(group)
+		Mx, My := spakeBasePoint(group, client)
+
+		wMx, wMy := crv.Params().ScalarMult(Mx, My, w)
+
+		var xGx, xGy *big.Int
+		x, xGx, xGy, err = elliptic.GenerateKey(crv, prng)
+		if err != nil {
+			return
+		}
+
+		Tx, Ty := crv.Params().Add(wMx, wMy, xGx, xGy)
+		T = elliptic.Marshal(crv, Tx, Ty)
+
+		return x, T, nil
+
+	default:
+		return nil, nil, fmt.Errorf("tls.newspake2: Unsupported group %v", group)
+	}
+}
+
+// C->S: T = w*M + x*G
+// S->C: S = w*N + y*G
+//
+// K = x * (S - w*N) = y * (T - w*M)
+
+// Generate an ephemeral `x` and return `K = x * (S - w*N)` (or the
+// appropriate server-side equivalents)
+func spake2KeyAgreement(group NamedGroup, client bool, S, x, w []byte) ([]byte, error) {
+	switch group {
+	case P256, P384, P521:
+		crv := curveFromNamedGroup(group)
+		Sx, Sy := elliptic.Unmarshal(crv, S)
+		Nx, Ny := spakeBasePoint(group, !client)
+
+		wNx, wNy := crv.Params().ScalarMult(Nx, Ny, w)
+		wNy.Neg(wNy)
+		wNy.Mod(wNy, crv.Params().P)
+
+		SwNx, SwNy := crv.Params().Add(Sx, Sy, wNx, wNy)
+		Kx, _ := crv.Params().ScalarMult(SwNx, SwNy, x)
+
+		xBytes := Kx.Bytes()
+		numBytes := len(crv.Params().P.Bytes())
+		ret := make([]byte, numBytes)
+		copy(ret[numBytes-len(xBytes):], xBytes)
+		return ret, nil
+
+	default:
+		return nil, fmt.Errorf("tls.spake2: Unsupported group %v", group)
+	}
+}

--- a/spake2_test.go
+++ b/spake2_test.go
@@ -1,0 +1,26 @@
+package mint
+
+import (
+	"testing"
+)
+
+func TestSPAKE2(t *testing.T) {
+	groups := []NamedGroup{P256, P384, P521}
+	w := []byte{0, 1, 2, 3, 4, 5, 6, 7}
+
+	for _, group := range groups {
+		x, T, err := newSPAKE2KeyShare(group, true, w)
+		assertNotError(t, err, "Failed to generate client key share")
+
+		y, S, err := newSPAKE2KeyShare(group, false, w)
+		assertNotError(t, err, "Failed to generate server key share")
+
+		Kc, err := spake2KeyAgreement(group, true, S, x, w)
+		assertNotError(t, err, "Failed to generate client key")
+
+		Ks, err := spake2KeyAgreement(group, false, T, y, w)
+		assertNotError(t, err, "Failed to generate server key")
+
+		assertByteEquals(t, Ks, Kc)
+	}
+}

--- a/spake2_test.go
+++ b/spake2_test.go
@@ -1,78 +1,88 @@
 package mint
 
 import (
-	"crypto"
 	"testing"
+)
 
-	_ "crypto/sha256"
-	_ "crypto/sha512"
+var (
+	nistGroupByName = map[string]NamedGroup{
+		"P256": P256,
+		"P384": P384,
+		"P521": P521,
+	}
+
+	passwordHashByName = map[string]PasswordHash{
+		"scrypt": PasswordHashScrypt,
+		"argon2": PasswordHashArgon2,
+	}
 )
 
 var (
 	client         = []byte("alice")
 	server         = []byte("bob")
 	spake2password = []byte("password")
-	spake2Suites   = []struct {
-		group NamedGroup
-		hash  passwordHash
-	}{
-		{group: P256, hash: makeHash(crypto.SHA256)},
-		{group: P384, hash: makeHash(crypto.SHA384)},
-		{group: P521, hash: makeHash(crypto.SHA512)},
+
+	spake2Algorithms = map[string][]string{
+		"group": {"P256", "P384", "P521"},
+		"hash":  {"argon2", "scrypt"},
 	}
 )
 
-func makeHash(hash crypto.Hash) passwordHash {
-	return func(pw []byte) ([]byte, error) {
-		h := hash.New()
-		h.Write(pw)
-		return h.Sum(nil), nil
-	}
+func testSPAKE2(t *testing.T, name string, p testInstanceState) {
+	group, groupOK := nistGroupByName[p["group"]]
+	hash, hashOK := passwordHashByName[p["hash"]]
+	assertTrue(t, groupOK && hashOK, "Configuration error")
+
+	w, err := encodeSPAKE2Password(group, hash, contextW, client, server, spake2password)
+	assertNotError(t, err, "Failed to generate password hash")
+
+	x, T, err := newSPAKE2KeyShare(group, true, w)
+	assertNotError(t, err, "Failed to generate client key share")
+
+	y, S, err := newSPAKE2KeyShare(group, false, w)
+	assertNotError(t, err, "Failed to generate server key share")
+
+	Kc, err := spake2KeyAgreement(group, true, S, x, w)
+	assertNotError(t, err, "Failed to generate client key")
+
+	Ks, err := spake2KeyAgreement(group, false, T, y, w)
+	assertNotError(t, err, "Failed to generate server key")
+
+	assertByteEquals(t, Ks, Kc)
 }
 
 func TestSPAKE2(t *testing.T) {
-	for _, c := range spake2Suites {
-		w, err := encodeSPAKE2Password(c.group, c.hash, contextW, client, server, spake2password)
-		assertNotError(t, err, "Failed to generate password hash")
+	runParametrizedTest(t, spake2Algorithms, testSPAKE2)
+}
 
-		x, T, err := newSPAKE2KeyShare(c.group, true, w)
-		assertNotError(t, err, "Failed to generate client key share")
+func testSPAKE2Plus(t *testing.T, name string, p testInstanceState) {
+	group, groupOK := nistGroupByName[p["group"]]
+	hash, hashOK := passwordHashByName[p["hash"]]
+	assertTrue(t, groupOK && hashOK, "Configuration error")
 
-		y, S, err := newSPAKE2KeyShare(c.group, false, w)
-		assertNotError(t, err, "Failed to generate server key share")
+	w0c, w1c, err := spake2pClientSetup(group, hash, client, server, spake2password)
+	assertNotError(t, err, "Failed to generate client parameters")
 
-		Kc, err := spake2KeyAgreement(c.group, true, S, x, w)
-		assertNotError(t, err, "Failed to generate client key")
+	w0s, Ls, err := spake2pServerSetup(group, hash, client, server, spake2password)
+	assertNotError(t, err, "Failed to generate server parameters")
+	assertByteEquals(t, w0c, w0s)
 
-		Ks, err := spake2KeyAgreement(c.group, false, T, y, w)
-		assertNotError(t, err, "Failed to generate server key")
+	x, T, err := newSPAKE2KeyShare(group, true, w0c)
+	assertNotError(t, err, "Failed to generate client key share")
 
-		assertByteEquals(t, Ks, Kc)
-	}
+	y, S, err := newSPAKE2KeyShare(group, false, w0s)
+	assertNotError(t, err, "Failed to generate server key share")
+
+	Zc, Vc, err := spake2pClient(group, S, x, w0c, w1c)
+	assertNotError(t, err, "Failed to generate client key")
+
+	Zs, Vs, err := spake2pServer(group, T, y, w0s, Ls)
+	assertNotError(t, err, "Failed to generate server key")
+
+	assertByteEquals(t, Zs, Zc)
+	assertByteEquals(t, Vs, Vc)
 }
 
 func TestSPAKE2Plus(t *testing.T) {
-	for _, c := range spake2Suites {
-		w0c, w1c, err := spake2pClientSetup(c.group, c.hash, client, server, spake2password)
-		assertNotError(t, err, "Failed to generate client parameters")
-
-		w0s, Ls, err := spake2pServerSetup(c.group, c.hash, client, server, spake2password)
-		assertNotError(t, err, "Failed to generate server parameters")
-		assertByteEquals(t, w0c, w0s)
-
-		x, T, err := newSPAKE2KeyShare(c.group, true, w0c)
-		assertNotError(t, err, "Failed to generate client key share")
-
-		y, S, err := newSPAKE2KeyShare(c.group, false, w0s)
-		assertNotError(t, err, "Failed to generate server key share")
-
-		Zc, Vc, err := spake2pClient(c.group, S, x, w0c, w1c)
-		assertNotError(t, err, "Failed to generate client key")
-
-		Zs, Vs, err := spake2pServer(c.group, T, y, w0s, Ls)
-		assertNotError(t, err, "Failed to generate server key")
-
-		assertByteEquals(t, Zs, Zc)
-		assertByteEquals(t, Vs, Vc)
-	}
+	runParametrizedTest(t, spake2Algorithms, testSPAKE2Plus)
 }

--- a/spake2_test.go
+++ b/spake2_test.go
@@ -86,3 +86,22 @@ func testSPAKE2Plus(t *testing.T, name string, p testInstanceState) {
 func TestSPAKE2Plus(t *testing.T) {
 	runParametrizedTest(t, spake2Algorithms, testSPAKE2Plus)
 }
+
+/*
+// Uncomment and run to re-generate conn test parameters
+func TestSPAKE2Setup(t *testing.T) {
+	serverName := []byte("example.com")
+	clientName := []byte("example.org")
+	password := []byte("example password")
+	group := P256
+	hash := PasswordHashArgon2
+
+	w0, w1, _ := spake2pClientSetup(group, hash, clientName, serverName, password)
+	fmt.Printf("w0: [%x]\n", w0)
+	fmt.Printf("w1: [%x]\n", w1)
+
+	w0, L, _ := spake2pServerSetup(group, hash, clientName, serverName, password)
+	fmt.Printf("w0 : [%x]\n", w0)
+	fmt.Printf("L : [%x]\n", L)
+}
+*/

--- a/spake2_test.go
+++ b/spake2_test.go
@@ -1,26 +1,78 @@
 package mint
 
 import (
+	"crypto"
 	"testing"
+
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 )
 
-func TestSPAKE2(t *testing.T) {
-	groups := []NamedGroup{P256, P384, P521}
-	w := []byte{0, 1, 2, 3, 4, 5, 6, 7}
+var (
+	client         = []byte("alice")
+	server         = []byte("bob")
+	spake2password = []byte("password")
+	spake2Suites   = []struct {
+		group NamedGroup
+		hash  passwordHash
+	}{
+		{group: P256, hash: makeHash(crypto.SHA256)},
+		{group: P384, hash: makeHash(crypto.SHA384)},
+		{group: P521, hash: makeHash(crypto.SHA512)},
+	}
+)
 
-	for _, group := range groups {
-		x, T, err := newSPAKE2KeyShare(group, true, w)
+func makeHash(hash crypto.Hash) passwordHash {
+	return func(pw []byte) ([]byte, error) {
+		h := hash.New()
+		h.Write(pw)
+		return h.Sum(nil), nil
+	}
+}
+
+func TestSPAKE2(t *testing.T) {
+	for _, c := range spake2Suites {
+		w, err := encodeSPAKE2Password(c.group, c.hash, contextW, client, server, spake2password)
+		assertNotError(t, err, "Failed to generate password hash")
+
+		x, T, err := newSPAKE2KeyShare(c.group, true, w)
 		assertNotError(t, err, "Failed to generate client key share")
 
-		y, S, err := newSPAKE2KeyShare(group, false, w)
+		y, S, err := newSPAKE2KeyShare(c.group, false, w)
 		assertNotError(t, err, "Failed to generate server key share")
 
-		Kc, err := spake2KeyAgreement(group, true, S, x, w)
+		Kc, err := spake2KeyAgreement(c.group, true, S, x, w)
 		assertNotError(t, err, "Failed to generate client key")
 
-		Ks, err := spake2KeyAgreement(group, false, T, y, w)
+		Ks, err := spake2KeyAgreement(c.group, false, T, y, w)
 		assertNotError(t, err, "Failed to generate server key")
 
 		assertByteEquals(t, Ks, Kc)
+	}
+}
+
+func TestSPAKE2Plus(t *testing.T) {
+	for _, c := range spake2Suites {
+		w0c, w1c, err := spake2pClientSetup(c.group, c.hash, client, server, spake2password)
+		assertNotError(t, err, "Failed to generate client parameters")
+
+		w0s, Ls, err := spake2pServerSetup(c.group, c.hash, client, server, spake2password)
+		assertNotError(t, err, "Failed to generate server parameters")
+		assertByteEquals(t, w0c, w0s)
+
+		x, T, err := newSPAKE2KeyShare(c.group, true, w0c)
+		assertNotError(t, err, "Failed to generate client key share")
+
+		y, S, err := newSPAKE2KeyShare(c.group, false, w0s)
+		assertNotError(t, err, "Failed to generate server key share")
+
+		Zc, Vc, err := spake2pClient(c.group, S, x, w0c, w1c)
+		assertNotError(t, err, "Failed to generate client key")
+
+		Zs, Vs, err := spake2pServer(c.group, T, y, w0s, Ls)
+		assertNotError(t, err, "Failed to generate server key")
+
+		assertByteEquals(t, Zs, Zc)
+		assertByteEquals(t, Vs, Vc)
 	}
 }

--- a/state-machine.go
+++ b/state-machine.go
@@ -57,14 +57,16 @@ type ConnectionOptions struct {
 type ConnectionParameters struct {
 	UsingPSK               bool
 	UsingDH                bool
+	UsingSPAKE2            bool
 	ClientSendingEarlyData bool
 	UsingEarlyData         bool
 	RejectedEarlyData      bool
 	UsingClientAuth        bool
 
-	CipherSuite CipherSuite
-	ServerName  string
-	NextProto   string
+	CipherSuite    CipherSuite
+	ServerName     string
+	NextProto      string
+	SPAKE2Identity string
 }
 
 // Working state for the handshake.


### PR DESCRIPTION
This patch adds a PAKE key exchange mechanism using more or less the same mechanism proposed in [draft-barnes-tls-pake](https://github.com/bifurcation/tls-pake/blob/master/draft-barnes-tls-pake.md).  The only major difference is that the extension syntax is slightly modified to allow the client to offer multiple identities.