### PR TITLE
TLS 1.3 Final

### DIFF
--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -136,6 +136,15 @@ func (state clientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 		}
 	}
 
+	if len(state.Config.PSKModes) != 0 {
+		kem := &PSKKeyExchangeModesExtension{KEModes: state.Config.PSKModes}
+		err = ch.Extensions.Add(kem)
+		if err != nil {
+			logf(logTypeHandshake, "Error adding PSKKeyExchangeModes extension: %v", err)
+			return nil, nil, AlertInternalError
+		}
+	}
+
 	// Run the external extension handler.
 	if state.Config.ExtensionHandler != nil {
 		err := state.Config.ExtensionHandler.Send(HandshakeTypeClientHello, &ch.Extensions)
@@ -188,12 +197,6 @@ func (state clientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 		// Signal supported PSK key exchange modes
 		if len(state.Config.PSKModes) == 0 {
 			logf(logTypeHandshake, "PSK selected, but no PSKModes")
-			return nil, nil, AlertInternalError
-		}
-		kem := &PSKKeyExchangeModesExtension{KEModes: state.Config.PSKModes}
-		err = ch.Extensions.Add(kem)
-		if err != nil {
-			logf(logTypeHandshake, "Error adding PSKKeyExchangeModes extension: %v", err)
 			return nil, nil, AlertInternalError
 		}
 

--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -416,6 +416,7 @@ func (state clientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 		// mode. In DTLS, we also need to bump the sequence number.
 		// This is a pre-existing defect in Mint. Issue #175.
 		logf(logTypeHandshake, "[ClientStateWaitSH] -> [ClientStateStart]")
+		state.hsCtx.SetVersion(tls12Version) // Everything after this should be 1.2.
 		return clientStateStart{
 			Config:            state.Config,
 			Opts:              state.Opts,

--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -89,7 +89,7 @@ func (state clientStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 	logf(logTypeHandshake, "opts: %+v", state.Opts)
 
 	// supported_versions, supported_groups, signature_algorithms, server_name
-	sv := SupportedVersionsExtension{HandshakeType: HandshakeTypeClientHello, Versions: []uint16{supportedVersion}}
+	sv := SupportedVersionsExtension{HandshakeType: HandshakeTypeClientHello, Versions: []uint16{tls13Version}}
 	sni := ServerNameExtension(state.Opts.ServerName)
 	sg := SupportedGroupsExtension{Groups: state.Config.Groups}
 	sa := SignatureAlgorithmsExtension{Algorithms: state.Config.SignatureSchemes}
@@ -357,7 +357,7 @@ func (state clientStateWaitSH) Next(hr handshakeMessageReader) (HandshakeState, 
 		logf(logTypeHandshake, "[ClientStateWaitSH] no supported_versions extension")
 		return nil, nil, AlertMissingExtension
 	}
-	if supportedVersions.Versions[0] != supportedVersion {
+	if supportedVersions.Versions[0] != tls13Version {
 		logf(logTypeHandshake, "[ClientStateWaitSH] unsupported version [%x]", supportedVersions.Versions[0])
 		return nil, nil, AlertProtocolVersion
 	}

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	supportedVersion  uint16 = 0x0304
+	tls13Version      uint16 = 0x0304
 	tls12Version      uint16 = 0x0303
 	tls10Version      uint16 = 0x0301
 	dtls12WireVersion uint16 = 0xfefd

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	supportedVersion  uint16 = 0x7f17 // draft-23
+	supportedVersion  uint16 = 0x7f1c // draft-28
 	tls12Version      uint16 = 0x0303
 	tls10Version      uint16 = 0x0301
 	dtls12WireVersion uint16 = 0xfefd

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	supportedVersion  uint16 = 0x7f1c // draft-28
+	supportedVersion  uint16 = 0x0304
 	tls12Version      uint16 = 0x0303
 	tls10Version      uint16 = 0x0301
 	dtls12WireVersion uint16 = 0xfefd

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	supportedVersion  uint16 = 0x7f16 // draft-22
+	supportedVersion  uint16 = 0x7f17 // draft-23
 	tls12Version      uint16 = 0x0303
 	tls10Version      uint16 = 0x0301
 	dtls12WireVersion uint16 = 0xfefd
@@ -118,7 +118,7 @@ const (
 	ExtensionTypeSupportedGroups     ExtensionType = 10
 	ExtensionTypeSignatureAlgorithms ExtensionType = 13
 	ExtensionTypeALPN                ExtensionType = 16
-	ExtensionTypeKeyShare            ExtensionType = 40
+	ExtensionTypeKeyShare            ExtensionType = 51
 	ExtensionTypePreSharedKey        ExtensionType = 41
 	ExtensionTypeEarlyData           ExtensionType = 42
 	ExtensionTypeSupportedVersions   ExtensionType = 43

--- a/conn_test.go
+++ b/conn_test.go
@@ -1691,6 +1691,38 @@ func TestDTLSOutOfEpochPostHSDiscard(t *testing.T) {
 	assertEquals(t, err, AlertWouldBlock)
 }
 
+func TestHRRRecordVersion(t *testing.T) {
+	cConn, sConn := pipe()
+	cbConn := newBufferedConn(cConn)
+	sbConn := newBufferedConn(sConn)
+
+	cconf := *pskConfig
+	cconf.NonBlocking = true
+	client := Client(cbConn, &cconf)
+	sconf := *hrrConfig
+	sconf.NonBlocking = true
+	cp, err := NewDefaultCookieProtector()
+	assertNotError(t, err, "Couldn't make default cookie protector")
+	sconf.CookieProtector = cp
+	server := Server(sbConn, &sconf)
+
+	hsUntilBlocked(t, client, cbConn) // CH1
+	cbConn.Flush()
+	hsUntilBlocked(t, server, sbConn) // HRR
+	sbConn.Flush()
+	hsUntilBlocked(t, client, cbConn) // CH2
+
+	p := make([]byte, 3)
+	_, err = io.ReadFull(&cbConn.buffer, p)
+	assertNotError(t, err, "should have records available")
+	expectedRecord := []byte{
+		byte(RecordTypeHandshake),
+		byte(tls12Version >> 8),
+		byte(tls12Version & 0xff),
+	}
+	assertByteEquals(t, p, expectedRecord)
+}
+
 // Test for issue #175.
 func TestEarlyDataWithHRR(t *testing.T) {
 	cConn, sConn := pipe()

--- a/conn_test.go
+++ b/conn_test.go
@@ -379,9 +379,9 @@ func testConnInner(t *testing.T, name string, p testInstanceState) {
 
 	done := make(chan bool)
 	go func(t *testing.T) {
+		defer close(done)
 		serverAlert = server.Handshake()
 		assertEquals(t, serverAlert, AlertNoAlert)
-		done <- true
 	}(t)
 
 	clientAlert = client.Handshake()

--- a/handshake-messages.go
+++ b/handshake-messages.go
@@ -406,7 +406,7 @@ func (cr *CertificateRequestBody) Unmarshal(data []byte) (int, error) {
 type NewSessionTicketBody struct {
 	TicketLifetime uint32
 	TicketAgeAdd   uint32
-	TicketNonce    []byte        `tls:"head=1,min=1"`
+	TicketNonce    []byte        `tls:"head=1"`
 	Ticket         []byte        `tls:"head=2,min=1"`
 	Extensions     ExtensionList `tls:"head=2"`
 }

--- a/handshake-messages_test.go
+++ b/handshake-messages_test.go
@@ -18,8 +18,8 @@ const (
 
 var (
 	supportedVersionHex = hex.EncodeToString([]byte{
-		byte(supportedVersion >> 8),
-		byte(supportedVersion & 0xff),
+		byte(tls13Version >> 8),
+		byte(tls13Version & 0xff),
 	})
 	tls12VersionHex = hex.EncodeToString([]byte{
 		byte(tls12Version >> 8),

--- a/negotiation.go
+++ b/negotiation.go
@@ -9,9 +9,9 @@ import (
 
 func VersionNegotiation(offered, supported []uint16) (bool, uint16) {
 	for _, offeredVersion := range offered {
-		for _, supportedVersion := range supported {
-			logf(logTypeHandshake, "[server] version offered by client [%04x] <> [%04x]", offeredVersion, supportedVersion)
-			if offeredVersion == supportedVersion {
+		for _, tls13Version := range supported {
+			logf(logTypeHandshake, "[server] version offered by client [%04x] <> [%04x]", offeredVersion, tls13Version)
+			if offeredVersion == tls13Version {
 				// XXX: Should probably be highest supported version, but for now, we
 				// only support one version, so it doesn't really matter.
 				return true, offeredVersion

--- a/record-layer_test.go
+++ b/record-layer_test.go
@@ -16,9 +16,9 @@ const (
 	ivHex          = "2b7fbbf689f240e3e7aa44a6"
 	paddingLength  = 4
 	sequenceChange = 17
-	ciphertext0Hex = "1703010016621a75932c037ff74d2a9ec7776790e09dcd4811db97"
-	ciphertext1Hex = "170301001a621a75932c03076e386b3cebbb8dbf2f37e49ad3e82a70a17833"
-	ciphertext2Hex = "170301001a1da650d5da822b7f4eba67f954767fcbbbd4c4bc7f1c61daf701"
+	ciphertext0Hex = "1703010016621a75932c03e2bd29daedb50c27a2c70fc55934e6f3"
+	ciphertext1Hex = "170301001a621a75932c03076e386be13a583ce0d6789c6b6306ffadc377fc"
+	ciphertext2Hex = "170301001a1da650d5da822b7f4ebaba28b7c72032f4ac350c91c9bcb8f8ce"
 )
 
 func newRecordLayerFromBytes(b []byte) *RecordLayer {

--- a/server-state-machine.go
+++ b/server-state-machine.go
@@ -163,7 +163,7 @@ func (state serverStateStart) Next(hr handshakeMessageReader) (HandshakeState, [
 		logf(logTypeHandshake, "[ServerStateStart] Client did not send supported_versions")
 		return nil, nil, AlertProtocolVersion
 	}
-	versionOK, _ := VersionNegotiation(supportedVersions.Versions, []uint16{supportedVersion})
+	versionOK, _ := VersionNegotiation(supportedVersions.Versions, []uint16{tls13Version})
 	if !versionOK {
 		logf(logTypeHandshake, "[ServerStateStart] Client does not support the same version")
 		return nil, nil, AlertProtocolVersion
@@ -416,7 +416,7 @@ func (state *serverStateStart) generateHRR(cs CipherSuite, legacySessionId []byt
 
 	sv := &SupportedVersionsExtension{
 		HandshakeType: HandshakeTypeServerHello,
-		Versions:      []uint16{supportedVersion},
+		Versions:      []uint16{tls13Version},
 	}
 
 	if err := hrr.Extensions.Add(sv); err != nil {
@@ -483,7 +483,7 @@ func (state serverStateNegotiated) Next(_ handshakeMessageReader) (HandshakeStat
 
 	err := sh.Extensions.Add(&SupportedVersionsExtension{
 		HandshakeType: HandshakeTypeServerHello,
-		Versions:      []uint16{supportedVersion},
+		Versions:      []uint16{tls13Version},
 	})
 	if err != nil {
 		logf(logTypeHandshake, "[ServerStateNegotiated] Error adding supported_versions extension [%v]", err)


### PR DESCRIPTION
This should make mint interoperable for draft-28 changes in *TLS*.  I can take a swing at implementing the record layer changes for DTLS, but that is a far bigger change and I'd like to do that separately.  (Either that, or get @ekr to do those because I made the changes in NSS.)