### PR TITLE
Enable fields to be marked for omission from a struct

### DIFF
--- a/syntax/decode.go
+++ b/syntax/decode.go
@@ -102,6 +102,13 @@ func newTypeDecoder(t reflect.Type) decoderFunc {
 
 ///// Specific decoders below
 
+func omitDecoder(d *decodeState, v reflect.Value, opts decOpts) int {
+	// This space intentionally left blank
+	return 0
+}
+
+//////////
+
 func unmarshalerDecoder(d *decodeState, v reflect.Value, opts decOpts) int {
 	um, ok := v.Interface().(Unmarshaler)
 	if !ok {
@@ -312,6 +319,11 @@ func newStructDecoder(t reflect.Type) decoderFunc {
 
 		tag := f.Tag.Get("tls")
 		tagOpts := parseTag(tag)
+
+		if tagOpts[omitOption] > 0 {
+			sd.fieldDecs[i] = omitDecoder
+			continue
+		}
 
 		sd.fieldOpts[i] = decOpts{
 			head:   tagOpts["head"],

--- a/syntax/encode.go
+++ b/syntax/encode.go
@@ -96,6 +96,12 @@ func newTypeEncoder(t reflect.Type) encoderFunc {
 
 ///// Specific encoders below
 
+func omitEncoder(e *encodeState, v reflect.Value, opts encOpts) {
+	// This space intentionally left blank
+}
+
+//////////
+
 func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
 	if v.Kind() == reflect.Ptr && v.IsNil() {
 		panic(fmt.Errorf("Cannot encode nil pointer"))
@@ -242,6 +248,11 @@ func newStructEncoder(t reflect.Type) encoderFunc {
 		f := t.Field(i)
 		tag := f.Tag.Get("tls")
 		tagOpts := parseTag(tag)
+
+		if tagOpts[omitOption] > 0 {
+			se.fieldEncs[i] = omitEncoder
+			continue
+		}
 
 		se.fieldOpts[i] = encOpts{
 			head:   tagOpts["head"],

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -174,6 +174,18 @@ func TestSuccessCases(t *testing.T) {
 			value:    struct{ V *uint16 }{V: &dummyUint16},
 			encoding: unhex("B0A0"),
 		},
+		"struct-omit": {
+			value: struct {
+				A uint16
+				B uint16 `tls:"omit"`
+				C uint16
+			}{
+				A: 0xA0A0,
+				B: 0x0000, // Can be anything on marshal, but will be zero on unmarshal
+				C: 0xC0C0,
+			},
+			encoding: unhex("A0A0C0C0"),
+		},
 
 		// Marshaler
 		"marshaler": {

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -10,6 +10,7 @@ import (
 type tagOptions map[string]uint
 
 var (
+	omitOption   = "omit"
 	varintOption = "varint"
 
 	headOptionNone   = "none"
@@ -24,6 +25,11 @@ var (
 func parseTag(tag string) tagOptions {
 	opts := tagOptions{}
 	for _, token := range strings.Split(tag, ",") {
+		if token == omitOption {
+			opts[omitOption] = 1
+			break
+		}
+
 		if token == varintOption {
 			opts[varintOption] = 1
 			continue


### PR DESCRIPTION
This way you can have structs that marshal / unmarshal as TLS, but also have extra information that is produced locally.  The proposed syntax is:

```
type Foo struct {
  A uint16
  B uint16 `tls:"omit"`
  C uint16
}
```