### PR TITLE
Pack multiple handshake messages into a single record

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 type pipeConn struct {
+	label  string
 	closed bool
 	r      *bytes.Buffer
 	w      *bytes.Buffer
@@ -29,6 +30,9 @@ type pipeConn struct {
 func pipe() (client *pipeConn, server *pipeConn) {
 	client = new(pipeConn)
 	server = new(pipeConn)
+
+	client.label = "client"
+	server.label = "server"
 
 	c2s := bytes.NewBuffer(nil)
 	server.r = c2s
@@ -64,6 +68,8 @@ func (p *pipeConn) Read(data []byte) (n int, err error) {
 }
 
 func (p *pipeConn) Write(data []byte) (n int, err error) {
+	logf(logTypePipe, "[%s] write: %d %x\n", p.label, len(data), data)
+
 	p.wLock.Lock()
 	defer p.wLock.Unlock()
 	if p.closed {

--- a/handshake-layer.go
+++ b/handshake-layer.go
@@ -532,12 +532,11 @@ func (h *HandshakeLayer) writeFragment(hm *HandshakeMessage, start int, room int
 			},
 			hm.cipher, 0)
 	} else {
-		err = h.conn.(*DefaultRecordLayer).writeRecordWithPadding(
+		err = h.conn.WriteRecord(
 			&TLSPlaintext{
 				contentType: RecordTypeHandshake,
 				fragment:    buf,
-			},
-			hm.cipher, 0)
+			})
 	}
 	return true, start + bodylen, err
 }

--- a/log.go
+++ b/log.go
@@ -18,6 +18,7 @@ const (
 	logTypeNegotiation = "negotiation"
 	logTypeIO          = "io"
 	logTypeFrameReader = "frame"
+	logTypePipe        = "pipe"
 	logTypeVerbose     = "verbose"
 )
 


### PR DESCRIPTION
Right now, mint sends an individual record for every handshake message, which incurs at least 17 bytes of overhead per handshake message (16-byte tag + content type).  With this PR, when not in datagram mode, mint will aggregate multiple handshake messages into a single record.  There is no change to the behavior in datagram mode.

This PR also adds a new log type `pipe`, which allows you to log data being sent between client and server.