### PR TITLE
Change the signature context according to protocol role

### DIFF
--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -819,7 +819,7 @@ func (state clientStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 	logf(logTypeHandshake, "Handshake Hash to be verified: [%d] %x", len(hcv), hcv)
 
 	serverPublicKey := state.serverCertificate.CertificateList[0].CertData.PublicKey
-	if err := certVerify.Verify(serverPublicKey, hcv); err != nil {
+	if err := certVerify.Verify(true, serverPublicKey, hcv); err != nil {
 		logf(logTypeHandshake, "[ClientStateWaitCV] Server signature failed to verify")
 		return nil, nil, AlertHandshakeFailure
 	}
@@ -1021,7 +1021,7 @@ func (state clientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeS
 			certificateVerify := &CertificateVerifyBody{Algorithm: certScheme}
 			logf(logTypeHandshake, "Creating CertVerify: %04x %v", certScheme, state.cryptoParams.Hash)
 
-			err = certificateVerify.Sign(cert.PrivateKey, hcv)
+			err = certificateVerify.Sign(false, cert.PrivateKey, hcv)
 			if err != nil {
 				logf(logTypeHandshake, "[ClientStateWaitFinished] Error signing CertificateVerify [%v]", err)
 				return nil, nil, AlertInternalError

--- a/crypto.go
+++ b/crypto.go
@@ -523,6 +523,8 @@ func HkdfExtract(hash crypto.Hash, saltIn, input []byte) []byte {
 }
 
 const (
+	clientCertVerifyContext             = "TLS 1.3, client CertificateVerify"
+	serverCertVerifyContext             = "TLS 1.3, server CertificateVerify"
 	labelExternalBinder                 = "ext binder"
 	labelResumptionBinder               = "res binder"
 	labelEarlyTrafficSecret             = "c e traffic"

--- a/server-state-machine.go
+++ b/server-state-machine.go
@@ -665,7 +665,7 @@ func (state serverStateNegotiated) Next(_ handshakeMessageReader) (HandshakeStat
 		hcv := handshakeHash.Sum(nil)
 		logf(logTypeHandshake, "Handshake Hash to be verified: [%d] %x", len(hcv), hcv)
 
-		err = certificateVerify.Sign(state.cert.PrivateKey, hcv)
+		err = certificateVerify.Sign(true, state.cert.PrivateKey, hcv)
 		if err != nil {
 			logf(logTypeHandshake, "[ServerStateNegotiated] Error signing CertificateVerify [%v]", err)
 			return nil, nil, AlertInternalError
@@ -1061,7 +1061,7 @@ func (state serverStateWaitCV) Next(hr handshakeMessageReader) (HandshakeState, 
 	logf(logTypeHandshake, "Handshake Hash to be verified: [%d] %x", len(hcv), hcv)
 
 	clientPublicKey := state.clientCertificate.CertificateList[0].CertData.PublicKey
-	if err := certVerify.Verify(clientPublicKey, hcv); err != nil {
+	if err := certVerify.Verify(false, clientPublicKey, hcv); err != nil {
 		logf(logTypeHandshake, "[ServerStateWaitCV] Failure in client auth verification [%v]", err)
 		return nil, nil, AlertHandshakeFailure
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -215,6 +215,7 @@ func TestExchangeData(t *testing.T) {
 
 	srv := <-srvCh
 	assertNotNil(t, srv, "Server should have completed handshake")
+	assertNotError(t, serr, "Error in server handshake")
 
 	buf := make([]byte, 16)
 	buf = buf[0:6]


### PR DESCRIPTION
Currently, mint uses incorrect context string when creating a CertificateVerify message for client auth.  This PR properly switches the context string, in order to conform with the specification.