### PR TITLE
Support raw public keys (RFC 7520)

### DIFF
--- a/client-state-machine.go
+++ b/client-state-machine.go
@@ -1072,7 +1072,7 @@ func (state clientStateWaitFinished) Next(hr handshakeMessageReader) (HandshakeS
 					certList[i] = CertificateEntry{CertData: entry.Raw}
 				}
 			} else {
-				certData, err := marshalSigningKey(cert.PublicKey)
+				certData, err := marshalSigningKey(cert.PrivateKey.Public())
 				if err != nil {
 					logf(logTypeHandshake, "[ClientStateWaitFinished] Unable to marshal raw public key [%v]", err)
 					return nil, nil, AlertInternalError

--- a/common.go
+++ b/common.go
@@ -125,6 +125,8 @@ const (
 	ExtensionTypeCookie              ExtensionType = 44
 	ExtensionTypePSKKeyExchangeModes ExtensionType = 45
 	ExtensionTypeTicketEarlyDataInfo ExtensionType = 46
+	ExtensionTypeClientCertType      ExtensionType = 19
+	ExtensionTypeServerCertType      ExtensionType = 20
 )
 
 // enum {...} NamedGroup
@@ -162,6 +164,19 @@ type KeyUpdateRequest uint8
 const (
 	KeyUpdateNotRequested KeyUpdateRequest = 0
 	KeyUpdateRequested    KeyUpdateRequest = 1
+)
+
+/*
+0 	X.509 	Y 	[RFC6091]
+1 	OpenPGP_RESERVED 	N 	[RFC6091][RFC8446] 	Used in TLS versions prior to 1.3.
+2 	Raw Public Key 	Y 	[RFC7250]
+3 	1609Dot2 	N
+*/
+type CertificateType uint8
+
+const (
+	CertificateTypeX509         CertificateType = 0
+	CertificateTypeRawPublicKey CertificateType = 2
 )
 
 type State uint8

--- a/conn.go
+++ b/conn.go
@@ -129,6 +129,11 @@ type Config struct {
 	NonBlocking      bool
 	UseDTLS          bool
 
+	// These bools are arranged in opposite directions so that their default
+	// values reflect the correct default semantics (certs yes, raw keys no)
+	AllowRawPublicKeys bool
+	ForbidCertificates bool
+
 	RecordLayer RecordLayerFactory
 
 	// The same config object can be shared among different connections, so it

--- a/conn.go
+++ b/conn.go
@@ -16,6 +16,7 @@ import (
 type Certificate struct {
 	Chain      []*x509.Certificate
 	PrivateKey crypto.Signer
+	PublicKey  crypto.PublicKey
 }
 
 type PreSharedKey struct {
@@ -255,7 +256,7 @@ var (
 type ConnectionState struct {
 	HandshakeState   State
 	CipherSuite      CipherSuiteParams     // cipher suite in use (TLS_RSA_WITH_RC4_128_SHA, ...)
-	PeerCertificates []*x509.Certificate   // certificate chain presented by remote peer
+	PeerCertificates [][]byte              // certificate chain presented by remote peer
 	VerifiedChains   [][]*x509.Certificate // verified chains built from PeerCertificates
 	NextProto        string                // Selected ALPN proto
 	UsingPSK         bool                  // Are we using PSK.

--- a/conn_test.go
+++ b/conn_test.go
@@ -1232,9 +1232,9 @@ func TestConnectionState(t *testing.T) {
 	serverCS := server.ConnectionState()
 	assertEquals(t, clientCS.CipherSuite.Suite, configClient.CipherSuites[0])
 	assertDeepEquals(t, clientCS.VerifiedChains, [][]*x509.Certificate{{serverCert}})
-	assertDeepEquals(t, clientCS.PeerCertificates, []*x509.Certificate{serverCert})
+	assertDeepEquals(t, clientCS.PeerCertificates, [][]byte{serverCert.Raw})
 	assertEquals(t, serverCS.CipherSuite.Suite, serverConfig.CipherSuites[0])
-	assertDeepEquals(t, serverCS.PeerCertificates, []*x509.Certificate{clientCert})
+	assertDeepEquals(t, serverCS.PeerCertificates, [][]byte{clientCert.Raw})
 }
 
 func TestDTLS(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -179,7 +179,7 @@ var (
 	psk  PreSharedKey
 	psks *PSKMapCache
 
-	basicConfig, dtlsConfig, nbConfig, nbDTLSConfig, hrrConfig, alpnConfig, pskConfig, pskDTLSConfig, pskECDHEConfig, pskDHEConfig, resumptionConfig, ffdhConfig, x25519Config *Config
+	basicConfig, dtlsConfig, nbConfig, nbDTLSConfig, hrrConfig, alpnConfig, rawConfig, pskConfig, pskDTLSConfig, pskECDHEConfig, pskDHEConfig, resumptionConfig, ffdhConfig, x25519Config *Config
 )
 
 func init() {
@@ -259,6 +259,13 @@ func init() {
 		ServerName:         serverName,
 		Certificates:       certificates,
 		NextProtos:         []string{"http/1.1", "h2"},
+		InsecureSkipVerify: true,
+	}
+
+	rawConfig = &Config{
+		ServerName:         serverName,
+		Certificates:       certificates,
+		AllowRawPublicKeys: true,
 		InsecureSkipVerify: true,
 	}
 
@@ -357,11 +364,13 @@ func checkConsistency(t *testing.T, client *Conn, server *Conn) {
 
 func testConnInner(t *testing.T, name string, p testInstanceState) {
 	// Configs array:
-	configs := map[string]*Config{"basic config": basicConfig,
-		"HRR":    hrrConfig,
-		"ALPN":   alpnConfig,
-		"FFDH":   ffdhConfig,
-		"x25519": x25519Config,
+	configs := map[string]*Config{
+		"basic config": basicConfig,
+		"HRR":          hrrConfig,
+		"ALPN":         alpnConfig,
+		"RawPK":        rawConfig,
+		"FFDH":         ffdhConfig,
+		"x25519":       x25519Config,
 	}
 
 	c := configs[p["config"]]
@@ -400,6 +409,7 @@ func TestBasicFlows(t *testing.T) {
 			"basic config",
 			"HRR",
 			"ALPN",
+			"RawPK",
 			"FFDH",
 			"x25519",
 		},

--- a/crypto.go
+++ b/crypto.go
@@ -328,6 +328,31 @@ func newSigningKey(sig SignatureScheme) (crypto.Signer, error) {
 	}
 }
 
+func marshalSigningKey(pub crypto.PublicKey) ([]byte, error) {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return x509.MarshalPKIXPublicKey(pub)
+
+	case *ecdsa.PublicKey:
+		return x509.MarshalPKIXPublicKey(pub)
+
+	// TODO support Ed25519
+
+	default:
+		return nil, fmt.Errorf("tls.marshalsigningkey: Unsupported public key type")
+	}
+}
+
+func unmarshalSigningKey(data []byte) (interface{}, error) {
+	pub, err := x509.ParsePKIXPublicKey(data)
+	if err == nil {
+		return pub, err
+	}
+
+	// TODO attempt to parse Ed25519
+	return nil, err
+}
+
 // XXX(rlb): Copied from crypto/x509
 type ecdsaSignature struct {
 	R, S *big.Int

--- a/handshake-messages_test.go
+++ b/handshake-messages_test.go
@@ -153,11 +153,11 @@ var (
 		CertificateRequestContext: []byte{0, 0, 0, 0},
 		CertificateList: []CertificateEntry{
 			{
-				CertData:   cert1,
+				CertData:   cert1.Raw,
 				Extensions: extListValidIn,
 			},
 			{
-				CertData:   cert2,
+				CertData:   cert2.Raw,
 				Extensions: extListValidIn,
 			},
 		},
@@ -166,7 +166,7 @@ var (
 		CertificateRequestContext: []byte{0, 0, 0, 0},
 		CertificateList: []CertificateEntry{
 			{
-				CertData:   cert1,
+				CertData:   cert1.Raw,
 				Extensions: extListSingleTooLongIn,
 			},
 		},
@@ -462,11 +462,11 @@ func TestCertificateMarshalUnmarshal(t *testing.T) {
 	certValidIn.CertificateRequestContext = originalContext
 
 	// Test marshal failure on no raw certa
-	originalRaw := cert1.Raw
-	cert1.Raw = []byte{}
+	originalCert := certValidIn.CertificateList[0].CertData
+	certValidIn.CertificateList[0].CertData = nil
 	out, err = certValidIn.Marshal()
 	assertError(t, err, "Marshaled a Certificate with an empty cert")
-	cert1.Raw = originalRaw
+	certValidIn.CertificateList[0].CertData = originalCert
 
 	// Test marshal failure on extension list marshal failure
 	out, err = certOverflowIn.Marshal()
@@ -500,12 +500,6 @@ func TestCertificateMarshalUnmarshal(t *testing.T) {
 	_, err = cert.Unmarshal(certValid)
 	assertError(t, err, "Unmarshaled a Certificate with truncated certificates")
 	certValid[8] ^= 0xFF
-
-	// Test unmarshal failure on malformed certificate
-	certValid[11] ^= 0xFF // Clobber first octet of first cert
-	_, err = cert.Unmarshal(certValid)
-	assertError(t, err, "Unmarshaled a Certificate with truncated certificates")
-	certValid[11] ^= 0xFF
 }
 
 func TestCertificateVerifyMarshalUnmarshal(t *testing.T) {

--- a/server-state-machine.go
+++ b/server-state-machine.go
@@ -702,7 +702,7 @@ func (state serverStateNegotiated) Next(_ handshakeMessageReader) (HandshakeStat
 				certList[i] = CertificateEntry{CertData: entry.Raw}
 			}
 		} else {
-			certData, err := marshalSigningKey(state.cert.PublicKey)
+			certData, err := marshalSigningKey(state.cert.PrivateKey.Public())
 			if err != nil {
 				logf(logTypeHandshake, "[ServerStateNegotiated] Unable to marshal raw public key [%v]", err)
 				return nil, nil, AlertInternalError

--- a/state-machine.go
+++ b/state-machine.go
@@ -57,6 +57,7 @@ type ConnectionOptions struct {
 type ConnectionParameters struct {
 	UsingPSK               bool
 	UsingDH                bool
+	UsingRawPublicKeys     bool
 	ClientSendingEarlyData bool
 	UsingEarlyData         bool
 	RejectedEarlyData      bool
@@ -97,7 +98,7 @@ type stateConnected struct {
 	clientTrafficSecret []byte
 	serverTrafficSecret []byte
 	exporterSecret      []byte
-	peerCertificates    []*x509.Certificate
+	peerCertificates    [][]byte
 	verifiedChains      [][]*x509.Certificate
 }
 


### PR DESCRIPTION
Main components here:

* Definition of the `client_certificate_type` and `server_certificate_type` extensions
* Related negotiation logic
* Generalization of certificate logic in the handshake to support both raw keys and certificates