### PR TITLE
Add support for optional<T>

### DIFF
--- a/syntax/decode_test.go
+++ b/syntax/decode_test.go
@@ -104,6 +104,14 @@ func TestDecodeErrors(t *testing.T) {
 			}{},
 			encoding: unhex("40"),
 		},
+
+		// Optional errors
+		"invalid-optional-flag": {
+			template: struct {
+				V *uint8 `tls:"optional"`
+			}{},
+			encoding: unhex("0203"),
+		},
 	}
 
 	for label, testCase := range errorCases {

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -60,7 +60,7 @@ func (cs *CrypticString) UnmarshalTLS(data []byte) (int, error) {
 }
 
 func TestSuccessCases(t *testing.T) {
-	dummyUint16 := uint16(0xB0A0)
+	dummyUint16 := uint16(0xFFFF)
 	testCases := map[string]struct {
 		value    interface{}
 		encoding []byte
@@ -172,7 +172,25 @@ func TestSuccessCases(t *testing.T) {
 		},
 		"struct-pointer": {
 			value:    struct{ V *uint16 }{V: &dummyUint16},
-			encoding: unhex("B0A0"),
+			encoding: unhex("FFFF"),
+		},
+
+		// Optional
+		"optional-absent": {
+			value: struct {
+				A *uint16 `tls:"optional"`
+			}{
+				A: nil,
+			},
+			encoding: unhex("00"),
+		},
+		"optional-present": {
+			value: struct {
+				A *uint16 `tls:"optional"`
+			}{
+				A: &dummyUint16,
+			},
+			encoding: unhex("01FFFF"),
 		},
 
 		// Marshaler

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -10,7 +10,8 @@ import (
 type tagOptions map[string]uint
 
 var (
-	varintOption = "varint"
+	varintOption   = "varint"
+	optionalOption = "optional"
 
 	headOptionNone   = "none"
 	headOptionVarint = "varint"
@@ -26,6 +27,9 @@ func parseTag(tag string) tagOptions {
 	for _, token := range strings.Split(tag, ",") {
 		if token == varintOption {
 			opts[varintOption] = 1
+			continue
+		} else if token == optionalOption {
+			opts[optionalOption] = 1
 			continue
 		}
 

--- a/syntax/tags_test.go
+++ b/syntax/tags_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func TestTagParsing(t *testing.T) {
-	opts := parseTag("=x,head=2,min=3,max=60000,unknown")
-	if len(opts) != 3 {
+	opts := parseTag("=x,head=2,min=3,max=60000,unknown,varint,optional")
+	if len(opts) != 5 {
 		t.Fatalf("Failed to parse all fields")
 	}
-	if opts["head"] != 2 || opts["min"] != 3 || opts["max"] != 60000 {
+	if opts["head"] != 2 || opts["min"] != 3 || opts["max"] != 60000 || opts[varintOption] != 1 || opts[optionalOption] != 1 {
 		t.Fatalf("Parsed fields incorrectly")
 	}
 }


### PR DESCRIPTION
Required for implementing MLS structs.  A pointer field in a struct can be tagged as "optional".  The null optional ("0x00") corresponds to the nil pointer.  Non-nil pointers are marshaled / unmarshaled as usual, with a 0x01 octet prefixed.