### PR TITLE
Options cleanup

### DIFF
--- a/syntax/encode.go
+++ b/syntax/encode.go
@@ -198,7 +198,7 @@ func (se *sliceEncoder) encode(e *encodeState, v reflect.Value, opts fieldOption
 		writeVarint(e, uint64(n))
 
 	case opts.headerSize > 0:
-		if n>>(8*opts.headerSize) > 0 {
+		if n>>uint(8*opts.headerSize) > 0 {
 			panic(fmt.Errorf("Encoded length too long for header length [%d, %d]", n, opts.headerSize))
 		}
 


### PR DESCRIPTION
Depends on #212 

This PR cleans up a few things about how struct tags are handled:

* Instead of parsing into a generic `map[string]int`, we now use a struct
* This struct is used in place of `encOpts` and `decOpts`, since they're the same anyway
* Tags are now checked for consistency at parse time
* Slice encoding is now a bit more systematic