### PR TITLE
Handle optional Marshalers

### DIFF
--- a/syntax/decode.go
+++ b/syntax/decode.go
@@ -344,12 +344,12 @@ func (pd *pointerDecoder) decode(d *decodeState, v reflect.Value, opts decOpts) 
 		readBase = 1
 		flag := d.Next(1)
 		switch flag[0] {
-		case 0:
+		case optionalFlagAbsent:
 			indir := v.Elem()
 			indir.Set(reflect.Zero(indir.Type()))
 			return 1
 
-		case 1:
+		case optionalFlagPresent:
 			// No action; continue as normal
 
 		default:

--- a/syntax/encode.go
+++ b/syntax/encode.go
@@ -98,8 +98,17 @@ func newTypeEncoder(t reflect.Type) encoderFunc {
 ///// Specific encoders below
 
 func marshalerEncoder(e *encodeState, v reflect.Value, opts encOpts) {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Ptr && v.IsNil() && !opts.optional {
 		panic(fmt.Errorf("Cannot encode nil pointer"))
+	}
+
+	if v.Kind() == reflect.Ptr && opts.optional {
+		if v.IsNil() {
+			writeUint(e, uint64(optionalFlagAbsent), 1)
+			return
+		}
+
+		writeUint(e, uint64(optionalFlagPresent), 1)
 	}
 
 	m, ok := v.Interface().(Marshaler)
@@ -268,17 +277,17 @@ type pointerEncoder struct {
 }
 
 func (pe pointerEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
-	if v.IsNil() && opts.optional {
-		writeUint(e, 0x00, 1)
-		return
-	}
-
-	if v.IsNil() {
-		panic(fmt.Errorf("Cannot marshal a struct containing a nil pointer"))
+	if v.IsNil() && !opts.optional {
+		panic(fmt.Errorf("Cannot encode nil pointer"))
 	}
 
 	if opts.optional {
-		writeUint(e, 0x01, 1)
+		if v.IsNil() {
+			writeUint(e, uint64(optionalFlagAbsent), 1)
+			return
+		}
+
+		writeUint(e, uint64(optionalFlagPresent), 1)
 	}
 
 	pe.base(e, v.Elem(), opts)

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -61,6 +61,7 @@ func (cs *CrypticString) UnmarshalTLS(data []byte) (int, error) {
 
 func TestSuccessCases(t *testing.T) {
 	dummyUint16 := uint16(0xFFFF)
+	crypticHello := CrypticString("hello")
 	testCases := map[string]struct {
 		value    interface{}
 		encoding []byte
@@ -192,10 +193,26 @@ func TestSuccessCases(t *testing.T) {
 			},
 			encoding: unhex("01FFFF"),
 		},
+		"optional-marshaler-absent": {
+			value: struct {
+				A *CrypticString `tls:"optional"`
+			}{
+				A: nil,
+			},
+			encoding: unhex("00"),
+		},
+		"optional-marshaler-present": {
+			value: struct {
+				A *CrypticString `tls:"optional"`
+			}{
+				A: &crypticHello,
+			},
+			encoding: unhex("01056e62646565"),
+		},
 
 		// Marshaler
 		"marshaler": {
-			value:    CrypticString("hello"),
+			value:    crypticHello,
 			encoding: unhex("056e62646565"),
 		},
 		"struct-marshaler": {

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -18,6 +18,9 @@ var (
 	headOptionVarint = "varint"
 	headValueNoHead  = uint(255)
 	headValueVarint  = uint(254)
+
+	optionalFlagAbsent  uint8 = 0
+	optionalFlagPresent uint8 = 1
 )
 
 // parseTag parses a struct field's "tls" tag as a comma-separated list of


### PR DESCRIPTION
The support for optional<T> in #210 omitted the case where the optional thing is a syntax.Marshaler.  This PR fixes that case.