### PR TITLE
Allow validation at TLS marshal/unmarshal time

### DIFF
--- a/syntax/decode_test.go
+++ b/syntax/decode_test.go
@@ -133,6 +133,12 @@ func TestDecodeErrors(t *testing.T) {
 			}{},
 			encoding: unhex("0203"),
 		},
+
+		// Validator errors
+		"invalid-validator": {
+			template: CrypticString(""),
+			encoding: unhex("056069677b6e"),
+		},
 	}
 
 	for label, testCase := range errorCases {

--- a/syntax/encode_test.go
+++ b/syntax/encode_test.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,8 @@ func TestEncodeErrors(t *testing.T) {
 		"invalid-optional-tag": struct {
 			V int `tls:"optional"`
 		}{V: 0},
+
+		"invalid-validator": CrypticString(strings.Repeat("A", 257)),
 	}
 
 	for label, badValue := range errorCases {

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -59,6 +59,19 @@ func (cs *CrypticString) UnmarshalTLS(data []byte) (int, error) {
 	return int(l + 1), nil
 }
 
+func (cs CrypticString) ValidForTLS() error {
+	if len(cs) > 256 {
+		return fmt.Errorf("CrypticString length to large: %d", len(cs))
+	}
+
+	fmt.Printf("val = [%s]\n", string(cs))
+	if string(cs) == "fnord" {
+		return fmt.Errorf("Forbidden value")
+	}
+
+	return nil
+}
+
 func TestSuccessCases(t *testing.T) {
 	dummyUint16 := uint16(0xFFFF)
 	crypticHello := CrypticString("hello")

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+// Allow types to mark themselves as valid for TLS to marshal/unmarshal
+type Validator interface {
+	ValidForTLS() error
+}
+
+var (
+	validatorType = reflect.TypeOf(new(Validator)).Elem()
+)
+
 // `tls:"head=2,min=2,max=255,varint"`
 
 type fieldOptions struct {


### PR DESCRIPTION
For example, with this change, an "enum" type can validate that the value to be encoded or the just-decoded value is a valid enum value, just by defining a single method:

```
func (e Enum) ValidForTLS() error {
  if (e == KnownEnumValue0) || (e == KnownEnumValue0) || ... {
    return nil
  }
  return fmt.Errorf("Unknown enum value")
}
```

This facility could also, of course, be used to validate more advanced types.