### PR TITLE
Allow serialization of Go maps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.13
     working_directory: /go/src/github.com/bifurcation/mint
     steps:
       - checkout

--- a/syntax/decode_test.go
+++ b/syntax/decode_test.go
@@ -133,6 +133,12 @@ func TestDecodeErrors(t *testing.T) {
 			}{},
 			encoding: unhex("0203"),
 		},
+
+		// Validator errors
+		"invalid-validator": {
+			template: CrypticString(""),
+			encoding: unhex("056069677b6e"),
+		},
 	}
 
 	for label, testCase := range errorCases {

--- a/syntax/encode_test.go
+++ b/syntax/encode_test.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,8 @@ func TestEncodeErrors(t *testing.T) {
 		"invalid-optional-tag": struct {
 			V int `tls:"optional"`
 		}{V: 0},
+
+		"invalid-validator": CrypticString(strings.Repeat("A", 257)),
 	}
 
 	for label, badValue := range errorCases {

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -64,7 +64,6 @@ func (cs CrypticString) ValidForTLS() error {
 		return fmt.Errorf("CrypticString length to large: %d", len(cs))
 	}
 
-	fmt.Printf("val = [%s]\n", string(cs))
 	if string(cs) == "fnord" {
 		return fmt.Errorf("Forbidden value")
 	}
@@ -169,6 +168,16 @@ func TestSuccessCases(t *testing.T) {
 				V: buffer(0x3FFF),
 			},
 			encoding: unhex("7FFF" + hexBuffer(0x3FFF)),
+		},
+
+		// Maps
+		"map": {
+			value: struct {
+				V map[uint16]uint8 `tls:"head=1"`
+			}{
+				V: map[uint16]uint8{2: 1, 1: 2},
+			},
+			encoding: unhex("06000102000201"),
 		},
 
 		// Struct

--- a/syntax/success_test.go
+++ b/syntax/success_test.go
@@ -59,6 +59,19 @@ func (cs *CrypticString) UnmarshalTLS(data []byte) (int, error) {
 	return int(l + 1), nil
 }
 
+func (cs CrypticString) ValidForTLS() error {
+	if len(cs) > 256 {
+		return fmt.Errorf("CrypticString length to large: %d", len(cs))
+	}
+
+	fmt.Printf("val = [%s]\n", string(cs))
+	if string(cs) == "fnord" {
+		return fmt.Errorf("Forbidden value")
+	}
+
+	return nil
+}
+
 func TestSuccessCases(t *testing.T) {
 	dummyUint16 := uint16(0xFFFF)
 	crypticHello := CrypticString("hello")

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -69,9 +69,10 @@ func (opts fieldOptions) Consistent() bool {
 }
 
 func (opts fieldOptions) ValidForType(t reflect.Type) bool {
-	sliceRequired := opts.omitHeader || opts.varintHeader || (opts.headerSize != 0) ||
+	headerType := t.Kind() == reflect.Slice || t.Kind() == reflect.Map
+	headerTags := opts.omitHeader || opts.varintHeader || (opts.headerSize != 0) ||
 		(opts.minSize != 0) || (opts.maxSize != 0)
-	if sliceRequired && t.Kind() != reflect.Slice {
+	if headerTags && !headerType {
 		return false
 	}
 

--- a/syntax/tags.go
+++ b/syntax/tags.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+// Allow types to mark themselves as valid for TLS to marshal/unmarshal
+type Validator interface {
+	ValidForTLS() error
+}
+
+var (
+	validatorType = reflect.TypeOf(new(Validator)).Elem()
+)
+
 // `tls:"head=2,min=2,max=255,varint"`
 
 type fieldOptions struct {


### PR DESCRIPTION
This is totally off-piste with regard to the specification, but so are many of the features we have in this repo.  The encoding strategy here effectively treats a `map[A]B` as a `[]struct{a A; b B}`, that is, as a sequence of key/value pairs.  In order to be canonical, the encoder sorts the pairs lexically by key.
