### PR TITLE
Add Go module metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/bifurcation/mint
+
+go 1.16
+
+require (
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
+)


### PR DESCRIPTION
Result of:

```
go mod init
go mod tidy
```

Required for things like `go test` in recent versions of Go.